### PR TITLE
Update version numbers - merge after rewrite-testing-frameworks and rewrite-spring are published

### DIFF
--- a/getting-started/getting-started.md
+++ b/getting-started/getting-started.md
@@ -39,7 +39,7 @@ In the pom.xml or build.gradle, add this entry to the `plugins` section to apply
 <plugin>
   <groupId>org.openrewrite.maven</groupId>
   <artifactId>rewrite-maven-plugin</artifactId>
-  <version>3.0.0-rc.4</version>
+  <version>3.0.0-rc.6</version>
 </plugin>
 ```
 {% endcode %}
@@ -50,7 +50,7 @@ In the pom.xml or build.gradle, add this entry to the `plugins` section to apply
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("3.0.0-rc.2")
+    id("org.openrewrite.rewrite").version("3.0.0-rc.4")
 }
 
 rewrite {
@@ -76,7 +76,7 @@ To configure this recipe to be active add this configuration to the plugin in th
 <plugin>
   <groupId>org.openrewrite.maven</groupId>
   <artifactId>rewrite-maven-plugin</artifactId>
-  <version>3.0.0-rc.4</version>
+  <version>3.0.0-rc.6</version>
   <configuration>
     <activeRecipes>
       <recipe>org.openrewrite.java.format.AutoFormat</recipe>
@@ -92,7 +92,7 @@ To configure this recipe to be active add this configuration to the plugin in th
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("3.0.0-rc.2")
+    id("org.openrewrite.rewrite").version("3.0.0-rc.4")
 }
 
 rewrite {
@@ -156,7 +156,7 @@ This creates a new recipe called `com.yourorg.VetToVeterinary`. Now add it to th
 <plugin>
   <groupId>org.openrewrite.maven</groupId>
   <artifactId>rewrite-maven-plugin</artifactId>
-  <version>3.0.0-rc.4</version>
+  <version>3.0.0-rc.6</version>
   <configuration>
     <activeRecipes>
       <recipe>org.openrewrite.java.format.AutoFormat</recipe>
@@ -173,7 +173,7 @@ This creates a new recipe called `com.yourorg.VetToVeterinary`. Now add it to th
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("3.0.0-rc.2")
+    id("org.openrewrite.rewrite").version("3.0.0-rc.4")
 }
 
 rewrite {
@@ -208,7 +208,7 @@ After applying these steps, the relevant portions of your build file will look l
 <plugin>
   <groupId>org.openrewrite.maven</groupId>
   <artifactId>rewrite-maven-plugin</artifactId>
-  <version>3.0.0-rc.4</version>
+  <version>3.0.0-rc.6</version>
   <configuration>
     <activeRecipes>
       <recipe>org.openrewrite.java.format.AutoFormat</recipe>
@@ -220,7 +220,7 @@ After applying these steps, the relevant portions of your build file will look l
     <dependency>
       <groupId>org.openrewrite.recipe</groupId>
       <artifactId>rewrite-testing-frameworks</artifactId>
-      <version>1.0.0-rc.1</version>
+      <version>1.0.0-rc.2</version>
     </dependency>
   </dependencies>
 </plugin>
@@ -233,18 +233,18 @@ After applying these steps, the relevant portions of your build file will look l
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("3.0.0-rc.2")
+    id("org.openrewrite.rewrite").version("3.0.0-rc.4")
 }
 
 rewrite {
     activeRecipe(
         "org.openrewrite.java.format.AutoFormat",
         "com.yourorg.VetToVeterinary",
-        "org.openrewrite.java.testing.JUnit5Migration")
+        "org.openrewrite.java.testing.JUnit4to5Migration")
 }
 
 dependencies {
-    compileOnly("org.openrewrite.recipe:rewrite-testing-frameworks:1.0.0-rc.1")
+    compileOnly("org.openrewrite.recipe:rewrite-testing-frameworks:1.0.0-rc.2")
 
     // Other project dependencies
 }

--- a/getting-started/getting-started.md
+++ b/getting-started/getting-started.md
@@ -244,7 +244,7 @@ rewrite {
 }
 
 dependencies {
-    compileOnly("org.openrewrite.recipe:rewrite-testing-frameworks:1.0.0-rc.2")
+    compileOnly("org.openrewrite.recipe:rewrite-testing-frameworks:1.0.0-rc.3")
 
     // Other project dependencies
 }
@@ -267,4 +267,3 @@ Now that you're up and running with the rewrite-maven-plugin, you may be interes
 * [Maven Plugin Configuration](../reference/rewrite-maven-plugin.md)
 * [Gradle Plugin Configuration](../reference/gradle-plugin-configuration.md)
 * [Declarative YAML Format](../reference/yaml-format-reference.md)
-

--- a/reference/gradle-plugin-configuration.md
+++ b/reference/gradle-plugin-configuration.md
@@ -17,7 +17,7 @@ Apply the org.openrewrite.rewrite plugin to your build:
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("3.0.0-rc.2")
+    id("org.openrewrite.rewrite").version("3.0.0-rc.4")
 }
 rewrite {
     // Rewrite Extension Configuration
@@ -40,7 +40,7 @@ With these steps taken, your root build.gradle may look similar to this:
 
 ```groovy
  plugins {
-     id("org.openrewrite.rewrite").version("3.0.0-rc.2").apply(false)
+     id("org.openrewrite.rewrite").version("3.0.0-rc.4").apply(false)
  }
 
  subprojects {
@@ -66,7 +66,7 @@ The `rewrite` DSL exposes a few configuration options:
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("3.0.0-rc.2")
+    id("org.openrewrite.rewrite").version("3.0.0-rc.4")
 }
 rewrite {
     activeRecipe("com.yourorg.ExampleRecipe", "com.yourorg.ExampleRecipe2")
@@ -101,7 +101,7 @@ To make pre-packaged Rewrite recipes available to apply to your test code, add t
 
 ```groovy
 dependencies {
-    testCompileOnly("org.openrewrite.recipe:rewrite-testing-frameworks:1.0.0-rc.1")
+    testCompileOnly("org.openrewrite.recipe:rewrite-testing-frameworks:1.0.0-rc.2")
 }
 ```
 
@@ -112,7 +112,7 @@ Once a pre-packaged recipe is the appropriate classpath, you can tell the Gradle
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("3.0.0-rc.2")
+    id("org.openrewrite.rewrite").version("3.0.0-rc.4")
 }
 
 repositories {

--- a/reference/gradle-plugin-configuration.md
+++ b/reference/gradle-plugin-configuration.md
@@ -101,7 +101,7 @@ To make pre-packaged Rewrite recipes available to apply to your test code, add t
 
 ```groovy
 dependencies {
-    testCompileOnly("org.openrewrite.recipe:rewrite-testing-frameworks:1.0.0-rc.2")
+    testCompileOnly("org.openrewrite.recipe:rewrite-testing-frameworks:1.0.0-rc.3")
 }
 ```
 
@@ -158,4 +158,3 @@ Execute `gradle rewriteDiscover` to list the recipes available on your classpath
 * [Github project](https://github.com/openrewrite/rewrite-gradle-plugin)
 * [Issue Tracker](https://github.com/openrewrite/rewrite-gradle-plugin/issues)
 * [Gradle Plugin Portal Listing](https://plugins.gradle.org/plugin/org.openrewrite.rewrite)
-

--- a/reference/rewrite-maven-plugin.md
+++ b/reference/rewrite-maven-plugin.md
@@ -38,7 +38,7 @@ Note. the plugin scans the `compile`, `provided`, and `test` scopes for visitors
       <plugin>
         <groupId>org.openrewrite.maven</groupId>
         <artifactId>rewrite-maven-plugin</artifactId>
-        <version>3.0.0-rc.4</version>
+        <version>3.0.0-rc.6</version>
         <configuration>
           <activeRecipes>
             <recipe>org.openrewrite.java.Spring</recipe>
@@ -101,7 +101,7 @@ The output directory of the `rewrite.patch` file can be controlled by setting th
 <plugin>
     <groupId>org.openrewrite.maven</groupId>
     <artifactId>rewrite-maven-plugin</artifactId>
-    <version>3.0.0-rc.4</version>
+    <version>3.0.0-rc.6</version>
     <configuration>
         <reportOutputDirectory>.rewrite</reportOutputDirector>
     </configuration>

--- a/tutorials/modifying-methods-with-javatemplate.md
+++ b/tutorials/modifying-methods-with-javatemplate.md
@@ -65,12 +65,12 @@ This example requires the following dependencies:
 {% tab title="Gradle" %}
 ```groovy
 dependencies {
-    implementation("org.openrewrite:rewrite-java:7.0.0-rc.6")
+    implementation("org.openrewrite:rewrite-java:7.0.0-rc.8")
     
-    runtimeOnly("org.openrewrite:rewrite-java-11:7.0.0-rc.6")
-    runtimeOnly("org.openrewrite:rewrite-java-8:7.0.0-rc.6")
+    runtimeOnly("org.openrewrite:rewrite-java-11:7.0.0-rc.8")
+    runtimeOnly("org.openrewrite:rewrite-java-8:7.0.0-rc.8")
     
-    testImplementation("org.openrewrite:rewrite-test:7.0.0-rc.6")
+    testImplementation("org.openrewrite:rewrite-test:7.0.0-rc.8")
 }
 ```
 {% endtab %}
@@ -81,25 +81,25 @@ dependencies {
     <dependency>
         <groupId>org.openrewrite</groupId>
         <artifactId>rewrite-java</artifactId>
-        <version>7.0.0-rc.6</version>
+        <version>7.0.0-rc.8</version>
         <scope>compile</scope>
     </dependency>
     <dependency>
         <groupId>org.openrewrite</groupId>
         <artifactId>rewrite-java-8</artifactId>
-        <version>7.0.0-rc.6</version>
+        <version>7.0.0-rc.8</version>
         <scope>runtime</scope>
     </dependency>
     <dependency>
         <groupId>org.openrewrite</groupId>
         <artifactId>rewrite-java-11</artifactId>
-        <version>7.0.0-rc.6</version>
+        <version>7.0.0-rc.8</version>
         <scope>runtime</scope>
     </dependency>
     <dependency>
         <groupId>org.openrewrite</groupId>
         <artifactId>rewrite-test</artifactId>
-        <version>7.0.0-rc.6</version>
+        <version>7.0.0-rc.8</version>
         <scope>test</scope>
     </dependency>
 </dependencies>

--- a/tutorials/writing-a-java-refactoring-recipe.md
+++ b/tutorials/writing-a-java-refactoring-recipe.md
@@ -35,12 +35,12 @@ Since this is a Java refactoring visitor, take a compile-scope dependency on rew
 {% tab title="Gradle" %}
 ```kotlin
 dependencies {
-    implementation("org.openrewrite:rewrite-java:7.0.0-rc.6")
+    implementation("org.openrewrite:rewrite-java:7.0.0-rc.8")
     
-    testImplementation("org.openrewrite:rewrite-test:7.0.0-rc.6")
+    testImplementation("org.openrewrite:rewrite-test:7.0.0-rc.8")
     
-    testRuntimeOnly("org.openrewrite:rewrite-java-11:7.0.0-rc.6")
-    testRuntimeOnly("org.openrewrite:rewrite-java-8:7.0.0-rc.6")
+    testRuntimeOnly("org.openrewrite:rewrite-java-11:7.0.0-rc.8")
+    testRuntimeOnly("org.openrewrite:rewrite-java-8:7.0.0-rc.8")
 }
 ```
 {% endtab %}
@@ -51,25 +51,25 @@ dependencies {
     <dependency>
         <groupId>org.openrewrite</groupId>
         <artifactId>rewrite-java</artifactId>
-        <version>7.0.0-rc.6</version>
+        <version>7.0.0-rc.8</version>
         <scope>compile</scope>
     </dependency>
     <dependency>
         <groupId>org.openrewrite</groupId>
         <artifactId>rewrite-java-8</artifactId>
-        <version>7.0.0-rc.6</version>
+        <version>7.0.0-rc.8</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.openrewrite</groupId>
         <artifactId>rewrite-java-11</artifactId>
-        <version>7.0.0-rc.6</version>
+        <version>7.0.0-rc.8</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.openrewrite</groupId>
         <artifactId>rewrite-test</artifactId>
-        <version>7.0.0-rc.6</version>
+        <version>7.0.0-rc.8</version>
         <scope>test</scope>
     </dependency>
 </dependencies>


### PR DESCRIPTION
I didn't figure out publishing for rewrite-spring and its dependency rewrite-testing-frameworks before taking the day off. Once those are published merge this in and all the version numbers, and slight changes to recipe names, will be aligned.

@aegershman can you make sure that those modules get published and this merged in?
@pway99 I wanted to update the getting started guide to instruct users to run the spring boot 1->2 migration instead of the junit 4->5 migration but didn't get to it. Can you make sure that happens? I renamed the spring boot recipes slightly so double check that any recipe name you put into the docs is accurate 