### PR TITLE
Build plugin reference documentation patches

### DIFF
--- a/getting-started/getting-started.md
+++ b/getting-started/getting-started.md
@@ -39,7 +39,7 @@ In the pom.xml or build.gradle, add this entry to the `plugins` section to apply
 <plugin>
   <groupId>org.openrewrite.maven</groupId>
   <artifactId>rewrite-maven-plugin</artifactId>
-  <version>4.2.0</version>
+  <version>4.2.2</version>
 </plugin>
 ```
 {% endcode %}
@@ -50,7 +50,7 @@ In the pom.xml or build.gradle, add this entry to the `plugins` section to apply
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("4.2.0")
+    id("org.openrewrite.rewrite").version("4.2.1")
 }
 
 rewrite {
@@ -76,7 +76,7 @@ To configure this recipe to be active add this configuration to the plugin in th
 <plugin>
   <groupId>org.openrewrite.maven</groupId>
   <artifactId>rewrite-maven-plugin</artifactId>
-  <version>4.2.0</version>
+  <version>4.2.2</version>
   <configuration>
     <activeRecipes>
       <recipe>org.openrewrite.java.format.AutoFormat</recipe>
@@ -92,7 +92,7 @@ To configure this recipe to be active add this configuration to the plugin in th
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("4.2.0")
+    id("org.openrewrite.rewrite").version("4.2.1")
 }
 
 rewrite {
@@ -156,7 +156,7 @@ This creates a new recipe called `com.yourorg.VetToVeterinary`. Now add it to th
 <plugin>
   <groupId>org.openrewrite.maven</groupId>
   <artifactId>rewrite-maven-plugin</artifactId>
-  <version>4.2.0</version>
+  <version>4.2.2</version>
   <configuration>
     <activeRecipes>
       <recipe>org.openrewrite.java.format.AutoFormat</recipe>
@@ -173,7 +173,7 @@ This creates a new recipe called `com.yourorg.VetToVeterinary`. Now add it to th
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("4.2.0")
+    id("org.openrewrite.rewrite").version("4.2.1")
 }
 
 rewrite {
@@ -208,7 +208,7 @@ After applying these steps, the relevant portions of your build file will look l
 <plugin>
   <groupId>org.openrewrite.maven</groupId>
   <artifactId>rewrite-maven-plugin</artifactId>
-  <version>4.2.0</version>
+  <version>4.2.2</version>
   <configuration>
     <activeRecipes>
       <recipe>org.openrewrite.java.format.AutoFormat</recipe>
@@ -220,7 +220,7 @@ After applying these steps, the relevant portions of your build file will look l
     <dependency>
       <groupId>org.openrewrite.recipe</groupId>
       <artifactId>rewrite-spring</artifactId>
-      <version>4.2.0</version>
+      <version>4.2.2</version>
     </dependency>
   </dependencies>
 </plugin>
@@ -233,7 +233,7 @@ After applying these steps, the relevant portions of your build file will look l
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("4.2.0")
+    id("org.openrewrite.rewrite").version("4.2.1")
 }
 
 rewrite {
@@ -267,4 +267,3 @@ Now that you're up and running with the rewrite-maven-plugin, you may be interes
 * [Maven Plugin Configuration](../reference/rewrite-maven-plugin.md)
 * [Gradle Plugin Configuration](../reference/gradle-plugin-configuration.md)
 * [Declarative YAML Format](../reference/yaml-format-reference.md)
-

--- a/getting-started/recipe-development-environment.md
+++ b/getting-started/recipe-development-environment.md
@@ -117,7 +117,7 @@ dependencies {
         <artifactId>rewrite-xml</artifactId>
         <version>7.3.0</version>
         <scope>compile</scope>
-    </dependency>    
+    </dependency>
 
     <!-- For authoring tests for any kind of Recipe -->
     <dependency>
@@ -148,7 +148,7 @@ In order to be able to use Rewrite to modernize old projects it's important to b
 {% code title="build.gradle" %}
 ```groovy
 // See https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_cross_compilation
-tasks.withType(JavaCompile) {        
+tasks.withType(JavaCompile) {
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()
 }
@@ -159,11 +159,11 @@ tasks.withType(JavaCompile) {
 {% tab title="Maven" %}
 {% code title="pom.xml" %}
 ```markup
-  <!-- see https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html -->
-  <properties>
+<!-- see https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html -->
+<properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-  </properties>
+</properties>
 ```
 {% endcode %}
 {% endtab %}
@@ -295,4 +295,3 @@ With your project set up as instructed by this guide the jar produced by your bu
 * [Writing a Java Refactoring Recipe](../tutorials/writing-a-java-refactoring-recipe.md)
 * [Maven Plugin Configuration](../reference/rewrite-maven-plugin.md)
 * [Gradle Plugin Configuration](../reference/gradle-plugin-configuration.md)
-

--- a/reference/gradle-plugin-configuration.md
+++ b/reference/gradle-plugin-configuration.md
@@ -17,7 +17,7 @@ Apply the org.openrewrite.rewrite plugin to your build:
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite") version("4.2.0")
+    id("org.openrewrite.rewrite") version("4.2.1")
 }
 rewrite {
     // Rewrite Extension Configuration
@@ -40,7 +40,7 @@ With these steps taken, your root build.gradle may look similar to this:
 
 ```groovy
  plugins {
-     id("org.openrewrite.rewrite") version("4.2.0") apply(false)
+     id("org.openrewrite.rewrite") version("4.2.1") apply(false)
  }
 
  subprojects {
@@ -62,18 +62,20 @@ The `rewrite` DSL exposes a few configuration options:
 * `activeRecipe` - Explicitly turns on recipes by name \(the name given in the `specs.openrewrite.org/v1beta/recipe` resource\). No recipe is run unless explicitly turned on with this setting.
 * `activeStyle` - Explicitly turns on a style by name \(the name given in the `specs.openrewrite.org/v1beta/style` resource\). No style is applied unless explicitly turned on with this setting.
 * `configFile` - Where to look for a Rewrite YML configuration file somewhere in the project directory \(or really anywhere on disk\). This file is not required to exist. If not specified otherwise, the default value is `<root project directory>/rewrite.yml`.
+* `failOnDryRunResults` - Boolean flag toggling whether `rewriteDryRun` should throw an exception and non-zero exit code if changes are detected. Default is `false`. This is convenient for integrating `rewriteDryRun` as a continuous integration gate.
 
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite") version("4.2.0")
+    id("org.openrewrite.rewrite") version("4.2.1")
 }
 rewrite {
     activeRecipe("com.yourorg.ExampleRecipe", "com.yourorg.ExampleRecipe2")
     activeStyle("com.yourorg.ExampleStyle", "com.yourorg.ExampleStyle2")
 
-    // This is the default value of configFile. It is not necessary to specify this value
+    // These are default values. It is not necessary to supply these values manually.
     configFile = project.getRootProject().file("rewrite.yml")
+    failOnDryRunResults = false
 }
 ```
 
@@ -102,7 +104,7 @@ Once a pre-packaged recipe has been added to the `rewrite` dependency configurat
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite") version("4.2.0")
+    id("org.openrewrite.rewrite") version("4.2.1")
 }
 
 repositories {
@@ -121,7 +123,7 @@ rewrite {
 
 ## The "Run" Task
 
-Execute`gradle rewriteRun` to run the active recipes and apply the changes. This will write changes locally to your source files on disk. Afterwards, review the changes, and when you are comfortable with the changes, commit them. The `run` goal generates warnings in the build log wherever it makes changes to source files.
+Execute `gradle rewriteRun` to run the active recipes and apply the changes. This will write changes locally to your source files on disk. Afterwards, review the changes, and when you are comfortable with the changes, commit them. The `run` goal generates warnings in the build log wherever it makes changes to source files.
 
 ![Showing which files were changed and by what visitors](../.gitbook/assets/rewrite-fix-gradle-output%20%282%29%20%282%29%20%284%29%20%284%29%20%285%29%20%286%29.png)
 
@@ -131,11 +133,18 @@ After the goal finishes executing, run `git diff` \(or your VCS system's equival
 
 ## The "DryRun" Task
 
-Execute`gradle rewriteDryRun` to dry-run the active recipes and print which visitors would make changes to which files to the build log. This does not alter your source files on disk at all. This goal can be used to preview the changes that would be made by the active recipes.
+Execute `gradle rewriteDryRun` to dry-run the active recipes and print which visitors would make changes to which files to the build log. This does not alter your source files on disk at all. This goal can be used to preview the changes that would be made by the active recipes.
 
 ![Listing of source files that would be changed if rewriteRun were run](../.gitbook/assets/rewrite-warn-gradle-output%20%283%29%20%283%29%20%283%29%20%281%29.png)
 
-It could also be manually called in a continuous integration environment, and if you so choose, fail the continuous integration build if the build log contains any such warnings.
+`rewriteDryRun` can be used as a "gate" in a continuous integration environment by failing the build if `rewriteDryRun` detects changes to be made and `failOnDryRunResults` is set:
+
+```groovy
+rewrite {
+    activeRecipe("...")
+    failOnDryRunResults = true
+}
+```
 
 ## The "Discover" Task
 
@@ -148,4 +157,3 @@ Execute `gradle rewriteDiscover` to list the recipes available on your classpath
 * [Github project](https://github.com/openrewrite/rewrite-gradle-plugin)
 * [Issue Tracker](https://github.com/openrewrite/rewrite-gradle-plugin/issues)
 * [Gradle Plugin Portal Listing](https://plugins.gradle.org/plugin/org.openrewrite.rewrite)
-

--- a/tutorials/authoring-declarative-yaml-recipes.md
+++ b/tutorials/authoring-declarative-yaml-recipes.md
@@ -37,7 +37,7 @@ Now that a recipe named "com.yourorg.FooToBar" has been created set that recipe 
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite") version("4.2.0")
+    id("org.openrewrite.rewrite") version("4.2.1")
 }
 
 rewrite {
@@ -56,7 +56,7 @@ rewrite {
       <plugin>
         <groupId>org.openrewrite.maven</groupId>
         <artifactId>rewrite-maven-plugin</artifactId>
-        <version>4.2.0</version>
+        <version>4.2.2</version>
         <configuration>
           <activeRecipes>
             <recipe>com.yourorg.FooToBar</recipe>
@@ -99,7 +99,7 @@ Now when the next version of A is published its jar will include this recipe. As
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite") version("4.2.0")
+    id("org.openrewrite.rewrite") version("4.2.1")
 }
 
 dependencies {
@@ -129,7 +129,7 @@ rewrite {
       <plugin>
         <groupId>org.openrewrite.maven</groupId>
         <artifactId>rewrite-maven-plugin</artifactId>
-        <version>4.2.0</version>
+        <version>4.2.2</version>
         <configuration>
           <activeRecipes>
             <recipe>com.yourorg.FooToBar</recipe>

--- a/tutorials/automating-maven-dependency-management.md
+++ b/tutorials/automating-maven-dependency-management.md
@@ -33,7 +33,7 @@ First add the rewrite-maven-plugin to the pom.xml:
 <plugin>
     <groupId>org.openrewrite.maven</groupId>
     <artifactId>rewrite-maven-plugin</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.2</version>
     <configuration>
         <activeRecipes>
             <recipe>com.yourorg.LogbackInsight</recipe>
@@ -59,7 +59,7 @@ recipeList:
 ```
 {% endcode %}
 
-Now run `mvn rewrite:dryRun` . This wont make any changes to the project's files. It will produce a rewrite.patch file in the reports directory, with a link in the console log:
+Now run `mvn rewrite:dryRun` . This won't make changes to the project's files. It will produce a rewrite.patch file in the reports directory, with a link in the console log:
 
 {% code title="Console Log" %}
 ```text
@@ -79,7 +79,7 @@ At this point you have all of the information you need to manually exclude logba
 
 ## Switching SLF4J Implementations
 
-Use the rewrite recipes [ExcludeDependency ](../reference/recipes/maven/excludedependency.md)and [AddDependency](../reference/recipes/maven/adddependency.md) to ensure that only your preferred slf4j dependency is used. If a new transitive dependency on logback-classic appears in the future, ExcludeDependency will detect and exclude it. 
+Use the rewrite recipes [ExcludeDependency](../reference/recipes/maven/excludedependency.md)and [AddDependency](../reference/recipes/maven/adddependency.md) to ensure that only your preferred slf4j dependency is used. If a new transitive dependency on logback-classic appears in the future, ExcludeDependency will detect and exclude it. 
 
 Add this to your rewrite.yml:
 
@@ -108,7 +108,7 @@ And set the `com.yourorg.UseSlf4jSimple` recipe as active in your pom.xml:
 <plugin>
     <groupId>org.openrewrite.maven</groupId>
     <artifactId>rewrite-maven-plugin</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.2</version>
     <configuration>
         <activeRecipes>
             <recipe>com.yourorg.UseSlf4jSimple</recipe>
@@ -136,5 +136,5 @@ Of course, CI failures are always at least a little bit frustrating for develope
 
 ## Next Steps
 
-The dependency management recipes used in this guide aren't the only such recipes included in rewrite. See the [Maven ](../reference/recipes/maven/)recipe reference for the full listing of dependency management recipes. 
+The dependency management recipes used in this guide aren't the only such recipes included in rewrite. See the [Maven](../reference/recipes/maven/)recipe reference for the full listing of dependency management recipes. 
 

--- a/tutorials/migrate-from-junit-4-to-junit-5.md
+++ b/tutorials/migrate-from-junit-4-to-junit-5.md
@@ -299,7 +299,7 @@ If your project is a Spring or Spring-Boot project take a dependency on [rewrite
 <plugin>
   <groupId>org.openrewrite.maven</groupId>
   <artifactId>rewrite-maven-plugin</artifactId>
-  <version>4.2.0</version>
+  <version>4.2.2</version>
   <configuration>
     <activeRecipes>
       <recipe>org.openrewrite.java.spring.boot2.SpringBoot2JUnit4to5Migration</recipe>
@@ -322,7 +322,7 @@ If your project is a Spring or Spring-Boot project take a dependency on [rewrite
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("4.2.0")
+    id("org.openrewrite.rewrite").version("4.2.1")
 }
 
 rewrite {
@@ -330,7 +330,7 @@ rewrite {
 }
 
 dependencies {
-    rewrite("org.openrewrite.recipe:rewrite-spring:4.0.2")
+    rewrite("org.openrewrite.recipe:rewrite-spring:4.2.0")
 
     // Other project dependencies
 }
@@ -340,7 +340,7 @@ dependencies {
 {% endtabs %}
 
 {% hint style="info" %}
-`SpringBoot2JUnit4to5Migration`is a superset of the normal JUnit 4 to 5 and Mockito 1 to 3 recipes, with some additional Spring-specific functionality. If you activate this recipe it is not necessary to also activate the base JUnit or Mockito migration recipes.
+`SpringBoot2JUnit4to5Migration` is a superset of the normal JUnit 4 to 5 and Mockito 1 to 3 recipes, with some additional Spring-specific functionality. If you activate this recipe it is not necessary to also activate the base JUnit or Mockito migration recipes.
 {% endhint %}
 
 If your project is _not_ a Spring or Spring-Boot project take a dependency on [rewrite-testing-frameworks](https://github.com/openrewrite/rewrite-testing-frameworks) and activate the recipe `org.openrewrite.java.testing.junit5.JUnit5BestPractices`
@@ -352,7 +352,7 @@ If your project is _not_ a Spring or Spring-Boot project take a dependency on [r
 <plugin>
   <groupId>org.openrewrite.maven</groupId>
   <artifactId>rewrite-maven-plugin</artifactId>
-  <version>4.2.0</version>
+  <version>4.2.2</version>
   <configuration>
     <activeRecipes>
       <recipe>org.openrewrite.java.testing.junit5.JUnit5BestPractices</recipe>
@@ -375,7 +375,7 @@ If your project is _not_ a Spring or Spring-Boot project take a dependency on [r
 ```groovy
 plugins {
     id("java")
-    id("org.openrewrite.rewrite").version("4.2.0")
+    id("org.openrewrite.rewrite").version("4.2.1")
 }
 
 rewrite {
@@ -383,7 +383,7 @@ rewrite {
 }
 
 dependencies {
-    rewrite("org.openrewrite.recipe:rewrite-testing-frameworks:1.2.1")
+    rewrite("org.openrewrite.recipe:rewrite-testing-frameworks:1.3.0")
 
     // Other project dependencies
 }
@@ -393,4 +393,3 @@ dependencies {
 {% endtabs %}
 
 At this point you're ready to execute the migration by running `mvn rewrite:run` or `gradlew rewriteRun`. After running the migration you can inspect the results with `git diff` \(or equivalent\), manually fix anything that wasn't able to be migrated automatically, and commit the results.
-

--- a/v1beta/environment.md
+++ b/v1beta/environment.md
@@ -45,7 +45,7 @@ Rewrite's `Environment` abstraction provides discovery, activation, and configur
   </tbody>
 </table>
 
-The code below demonstrates how to manually construct an `Environment` and seed it with a variety of different resource loaders. 
+The code below demonstrates how to manually construct an `Environment` and seed it with a variety of different resource loaders.
 
 ```java
 File rewriteYml = ...;
@@ -70,5 +70,4 @@ try(InputStream rewriteInputStream = new FileInputStream(rewriteYml)) {
 }
 ```
 
-Once an instance of the `Environment` has been created, it can be interrogated to list all available recipes and styes. There are also facilities for retrieving the recipe descriptions which provides a description of the recipe and its available options. 
-
+Once an instance of the `Environment` has been created, it can be interrogated to list all available recipes and styes. There are also facilities for retrieving the recipe descriptions which provides a description of the recipe and its available options.


### PR DESCRIPTION
do not merge, going to fix up wording, formatting, and see about replacing some of the outdated screenshots with text to be more user-friendly + searchable.

- gradle to 4.2.1, maven to 4.2.2
- fail on dry run result

EDIT: fixing over the course of smaller commits