### PR TITLE
doc : template method has been removed

### DIFF
--- a/tutorials/modifying-methods-with-javatemplate.md
+++ b/tutorials/modifying-methods-with-javatemplate.md
@@ -102,7 +102,7 @@ Within the `ExpandCustomerInfoVisitor`, we will add logic to remove the abstract
     private class ExpandCustomerInfoVisitor extends JavaIsoVisitor<ExecutionContext> {
         ...
         // Template used to add a method body to "setCustomerInfo()" method declaration.
-        private final JavaTemplate addMethodBodyTemplate = template("")
+        private final JavaTemplate addMethodBodyTemplate = JavaTemplate.builder(this::getCursor, "")
                 .build();
          ...
     }


### PR DESCRIPTION
With version 7.8, the  incubating method `JavaVisitor.template()` has been removed, so the doc is no more up to date.