### PR TITLE
fixed wrong parameters on ChangePackage Recipe

### DIFF
--- a/getting-started/getting-started.md
+++ b/getting-started/getting-started.md
@@ -138,8 +138,8 @@ type: specs.openrewrite.org/v1beta/recipe
 name: com.yourorg.VetToVeterinary
 recipeList:
   - org.openrewrite.java.ChangePackage:
-      oldFullyQualifiedPackageName: org.springframework.samples.petclinic.vet
-      newFullyQualifiedPackageName: org.springframework.samples.petclinic.veterinary
+      oldPackageName: org.springframework.samples.petclinic.vet
+      newPackageName: org.springframework.samples.petclinic.veterinary
 ```
 {% endcode %}
 


### PR DESCRIPTION
In the example in the quickstart guide the wrong parameter names are used.
These are (no longer?) containing "FullyQualified"

Got the folllwoing errors:
```
[ERROR] Recipe validation error in newPackageName: is required
[ERROR] Recipe validation error in oldPackageName: is required
[ERROR] Recipe validation errors detected as part of one or more activeRecipe(s). Execution will continue regardless.
```