### PR TITLE
Update rewrite-maven-plugin version to 4.16.0

### DIFF
--- a/tutorials/quarkus-2.x-migration-from-quarkus-1.x.md
+++ b/tutorials/quarkus-2.x-migration-from-quarkus-1.x.md
@@ -38,7 +38,7 @@ dependencies {
       <plugin>
         <groupId>org.openrewrite.maven</groupId>
         <artifactId>rewrite-maven-plugin</artifactId>
-        <version>4.13.1</version>
+        <version>4.16.0</version>
         <configuration>
           <activeRecipes>
             <recipe>org.openrewrite.java.quarkus.quarkus2.Quarkus1to2Migration</recipe>


### PR DESCRIPTION
4.13.1 does not exist in https://repo.maven.apache.org/maven2/org/openrewrite/maven/rewrite-maven-plugin/. Update to latest available version