### PR TITLE
Fix example for remove annotation recipe, quote @ in rewrite.yml

### DIFF
--- a/reference/recipes/java/removeannotation.md
+++ b/reference/recipes/java/removeannotation.md
@@ -31,7 +31,7 @@ name: com.yourorg.RemoveAnnotationExample
 displayName: Remove annotation example
 recipeList:
   - org.openrewrite.java.RemoveAnnotation:
-      annotationPattern: @java.lang.SuppressWarnings("deprecation")
+      annotationPattern: '@java.lang.SuppressWarnings("deprecation")'
 ```
 {% endcode %}
 


### PR DESCRIPTION
Not quoting reserved char @ in rewrite.yml results in
```
[ERROR] found character '@' that cannot start any token. (Do not use @ for indentation)
[ERROR]  in 'reader', line 7, column 26:
[ERROR]           annotationPattern: @java.lang.SuppressWarnings("dep ... 
```