### PR TITLE
Fix examples using globs, quote * in rewrite.yml

### DIFF
--- a/reference/recipes/concourse/changevalue.md
+++ b/reference/recipes/concourse/changevalue.md
@@ -37,7 +37,7 @@ recipeList:
       keyPath: $.resources[?(@.type == 'git')].source.uri
       oldValue: null
       newValue: null
-      fileMatcher: **/pipeline*.yml
+      fileMatcher: '**/pipeline*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/concourse/updategitresourceuri.md
+++ b/reference/recipes/concourse/updategitresourceuri.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.concourse.UpdateGitResourceUri:
       oldURIPattern: https://github.com/openrewrite/rewrite
       newURI: git@gitlab.com:openrewrite/rewrite.git
-      fileMatcher: **/pipeline*.yml
+      fileMatcher: '**/pipeline*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/json/changekey.md
+++ b/reference/recipes/json/changekey.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.json.ChangeKey:
       oldKeyPath: $.subjects.kind
       newKey: kind
-      fileMatcher: **/application-*.json
+      fileMatcher: '**/application-*.json'
 ```
 {% endcode %}
 

--- a/reference/recipes/json/changevalue.md
+++ b/reference/recipes/json/changevalue.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.json.ChangeValue:
       oldKeyPath: $.subjects.kind
       value: 'Deployment'
-      fileMatcher: **/application-*.json
+      fileMatcher: '**/application-*.json'
 ```
 {% endcode %}
 

--- a/reference/recipes/json/deletekey.md
+++ b/reference/recipes/json/deletekey.md
@@ -33,7 +33,7 @@ displayName: Delete key example
 recipeList:
   - org.openrewrite.json.DeleteKey:
       keyPath: $.subjects.kind
-      fileMatcher: **/application-*.json
+      fileMatcher: '**/application-*.json'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/rbac/addruletorole.md
+++ b/reference/recipes/kubernetes/rbac/addruletorole.md
@@ -43,7 +43,7 @@ recipeList:
       resources: pods
       resourceNames: my-pod
       verbs: get,list
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/resource/capresourcevaluetomaximum.md
+++ b/reference/recipes/kubernetes/resource/capresourcevaluetomaximum.md
@@ -37,7 +37,7 @@ recipeList:
       resourceValueType: limits
       resourceType: memory
       resourceLimit: 2Gi
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/resource/findexceedsresourceratio.md
+++ b/reference/recipes/kubernetes/resource/findexceedsresourceratio.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.kubernetes.resource.FindExceedsResourceRatio:
       resourceType: memory
       ratioLimit: 2
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/resource/findexceedsresourcevalue.md
+++ b/reference/recipes/kubernetes/resource/findexceedsresourcevalue.md
@@ -37,7 +37,7 @@ recipeList:
       resourceValueType: limits
       resourceType: memory
       resourceLimit: 2Gi
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/search/findannotation.md
+++ b/reference/recipes/kubernetes/search/findannotation.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.kubernetes.search.FindAnnotation:
       annotationName: mycompany.io/annotation
       value: value.*
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/search/finddisallowedimagetags.md
+++ b/reference/recipes/kubernetes/search/finddisallowedimagetags.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.kubernetes.search.FindDisallowedImageTags:
       disallowedTags: latest
       includeInitContainers: false
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/search/findimage.md
+++ b/reference/recipes/kubernetes/search/findimage.md
@@ -39,7 +39,7 @@ recipeList:
       imageName: nginx
       imageTag: v1.2.3
       includeInitContainers: false
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/search/findmissingorinvalidannotation.md
+++ b/reference/recipes/kubernetes/search/findmissingorinvalidannotation.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.kubernetes.search.FindMissingOrInvalidAnnotation:
       annotationName: mycompany.io/annotation
       value: value.*
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/search/findmissingorinvalidlabel.md
+++ b/reference/recipes/kubernetes/search/findmissingorinvalidlabel.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.kubernetes.search.FindMissingOrInvalidLabel:
       labelName: mylabel
       value: value(.*)
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/search/findresourcemissingconfiguration.md
+++ b/reference/recipes/kubernetes/search/findresourcemissingconfiguration.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.kubernetes.search.FindResourceMissingConfiguration:
       resourceKind: Pod
       configurationPath: $.spec.containers.livenessProbe
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/services/findserviceexternalips.md
+++ b/reference/recipes/kubernetes/services/findserviceexternalips.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.kubernetes.services.FindServiceExternalIPs:
       externalIPs: 192.168.0.1
       findMissing: null
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/services/findservicesbytype.md
+++ b/reference/recipes/kubernetes/services/findservicesbytype.md
@@ -33,7 +33,7 @@ displayName: Service type example
 recipeList:
   - org.openrewrite.kubernetes.services.FindServicesByType:
       serviceType: NodePort
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/services/updateserviceexternalip.md
+++ b/reference/recipes/kubernetes/services/updateserviceexternalip.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.kubernetes.services.UpdateServiceExternalIP:
       ipToFind: 192.168.0.1
       ipToUpdate: 10.10.0.1
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/kubernetes/updatecontainerimagename.md
+++ b/reference/recipes/kubernetes/updatecontainerimagename.md
@@ -45,7 +45,7 @@ recipeList:
       imageToUpdate: nginx
       tagToUpdate: v1.2.3
       includeInitContainers: false
-      fileMatcher: **/pod-*.yml
+      fileMatcher: '**/pod-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/properties/addproperty.md
+++ b/reference/recipes/properties/addproperty.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.properties.AddProperty:
       property: management.metrics.enable.process.files
       value: true
-      fileMatcher: **/application-*.properties
+      fileMatcher: '**/application-*.properties'
 ```
 {% endcode %}
 

--- a/reference/recipes/properties/changepropertykey.md
+++ b/reference/recipes/properties/changepropertykey.md
@@ -37,7 +37,7 @@ recipeList:
       oldPropertyKey: management.metrics.binders.files.enabled
       newPropertyKey: management.metrics.enable.process.files
       relaxedBinding: null
-      fileMatcher: **/application-*.properties
+      fileMatcher: '**/application-*.properties'
 ```
 {% endcode %}
 

--- a/reference/recipes/properties/deleteproperty.md
+++ b/reference/recipes/properties/deleteproperty.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.properties.DeleteProperty:
       propertyKey: management.metrics.binders.files.enabled
       relaxedBinding: null
-      fileMatcher: **/application-*.properties
+      fileMatcher: '**/application-*.properties'
 ```
 {% endcode %}
 

--- a/reference/recipes/renamefile.md
+++ b/reference/recipes/renamefile.md
@@ -32,7 +32,7 @@ name: com.yourorg.RenameFileExample
 displayName: Rename a file example
 recipeList:
   - org.openrewrite.RenameFile:
-      fileMatcher: **/application-*.yml
+      fileMatcher: '**/application-*.yml'
       fileName: application.yml
 ```
 {% endcode %}

--- a/reference/recipes/yaml/changekey.md
+++ b/reference/recipes/yaml/changekey.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.yaml.ChangeKey:
       oldKeyPath: $.subjects.kind
       newKey: kind
-      fileMatcher: **/application-*.yml
+      fileMatcher: '**/application-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/yaml/changepropertykey.md
+++ b/reference/recipes/yaml/changepropertykey.md
@@ -37,7 +37,7 @@ recipeList:
       oldPropertyKey: management.metrics.binders.files.enabled
       newPropertyKey: management.metrics.enable.process.files
       relaxedBinding: null
-      fileMatcher: **/application-*.yml
+      fileMatcher: '**/application-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/yaml/changevalue.md
+++ b/reference/recipes/yaml/changevalue.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.yaml.ChangeValue:
       oldKeyPath: $.subjects.kind
       value: Deployment
-      fileMatcher: **/application-*.yml
+      fileMatcher: '**/application-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/yaml/copyvalue.md
+++ b/reference/recipes/yaml/copyvalue.md
@@ -35,7 +35,7 @@ recipeList:
   - org.openrewrite.yaml.CopyValue:
       oldKeyPath: $.source.kind
       newKey: $.dest.kind
-      fileMatcher: **/application-*.yml
+      fileMatcher: '**/application-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/yaml/deletekey.md
+++ b/reference/recipes/yaml/deletekey.md
@@ -33,7 +33,7 @@ displayName: Delete key example
 recipeList:
   - org.openrewrite.yaml.DeleteKey:
       keyPath: $.source.kind
-      fileMatcher: **/application-*.yml
+      fileMatcher: '**/application-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/yaml/deleteproperty.md
+++ b/reference/recipes/yaml/deleteproperty.md
@@ -37,7 +37,7 @@ recipeList:
       propertyKey: management.metrics.binders.files.enabled
       coalesce: true
       relaxedBinding: null
-      fileMatcher: **/application-*.yml
+      fileMatcher: '**/application-*.yml'
 ```
 {% endcode %}
 

--- a/reference/recipes/yaml/mergeyaml.md
+++ b/reference/recipes/yaml/mergeyaml.md
@@ -38,7 +38,7 @@ recipeList:
       yaml: labels: 
 	label-one: "value-one"
       acceptTheirs: null
-      fileMatcher: **/application-*.yml
+      fileMatcher: '**/application-*.yml'
 ```
 {% endcode %}
 


### PR DESCRIPTION
Not quoting reserved char * in rewrite.yml results in 

```
[ERROR]  in 'reader', line 10, column 20:
[ERROR]           fileMatcher: **/application-*.yml
[ERROR]                        ^
[ERROR] unexpected character found *(42)
[ERROR]  in 'reader', line 10, column 21:
[ERROR]           fileMatcher: **/application-*.yml
[ERROR]                         ^
```