### PR TITLE
Fix typo

### DIFF
--- a/reference/recipes/java/cleanup/isemptycalloncollections.md
+++ b/reference/recipes/java/cleanup/isemptycalloncollections.md
@@ -1,4 +1,4 @@
-# Use `Collections#isEmpty()` instead of comparing `size()`
+# Use `Collection#isEmpty()` instead of comparing `size()`
 
 ** org.openrewrite.java.cleanup.IsEmptyCallOnCollections**
 _Also check for _not_ `isEmpty()` when testing for not equal to zero size._


### PR DESCRIPTION
There's no `Collections.isEmpty()`, so it seems to be a typo of `Collection.isEmpty()`.