### PR TITLE
Fixed Typo

### DIFF
--- a/v1beta/javatemplate.md
+++ b/v1beta/javatemplate.md
@@ -8,7 +8,7 @@ More advanced refactoring recipes often require the construction of complex AST 
 
 ## Construction
 
-`JavaTemplate` are constructed within a `JavaVisitor` by calling `JavaTemplate.bulider()`:
+`JavaTemplate` are constructed within a `JavaVisitor` by calling `JavaTemplate.builder()`:
 
 ```java
 public class ChangeMethodInvocation extends JavaIsoVisitor<ExecutionContext> {


### PR DESCRIPTION
Hi Moderne team, just found and fixed a typo: `JavaTemplate.bulider()`