### PR TITLE
Apply .getResults() method on recipe.run()

### DIFF
--- a/tutorials/running-rewrite-without-build-tool-plugins.md
+++ b/tutorials/running-rewrite-without-build-tool-plugins.md
@@ -102,7 +102,7 @@ public class RunRewriteManually {
         List<J.CompilationUnit> cus = javaParser.parse(sourcePaths, projectDir, ctx);
 
         // collect results
-        List<Result> results = recipe.run(cus, ctx);
+        List<Result> results = recipe.run(cus, ctx).getResults();
 
         for (Result result : results) {
             // print diffs to the console


### PR DESCRIPTION
This PR fixes the error Incompatible types. Found org.openrewrite.RecipeRun, required: java.util.List<org.openrewrite.Result>