### PR TITLE
Rewrite the Java Refactoring Recipe tutorial

### DIFF
--- a/tutorials/authoring-recipes/writing-a-java-refactoring-recipe.md
+++ b/tutorials/authoring-recipes/writing-a-java-refactoring-recipe.md
@@ -4,12 +4,13 @@ description: Adding a method to a class that returns a String
 
 # Writing a Java Refactoring Recipe
 
-In this tutorial, we'll create a basic refactoring recipe that adds a method returning a `String` to a user-specified class. This `SayHelloRecipe` will take a class like this:
+To help you get started with writing recipes, this guide will walk you through all the steps needed to create a basic refactoring recipe. This
+`SayHelloRecipe` will add a `hello()` method to a user specified class if that class does not already have one. For example, it would take a class like this:
 
 ```java
 package com.yourorg;
 
-class A {
+class FooBar {
 
 }
 ```
@@ -19,46 +20,51 @@ And refactor it into a class like this:
 ```java
 package com.yourorg;
 
-class A {
+class FooBar {
     public String hello() {
-        return "Hello from com.yourorg.A!";
+        return "Hello from com.yourorg.FooBar!";
     }
-
 }
 ```
 
-This guide assumes you've already set up your [Recipe Development Environment](../../getting-started/recipe-development-environment.md).
+## Prerequisites
 
-## Defining SayHelloRecipe
+This guide assumes you've already set up your [Recipe Development Environment](../../getting-started/recipe-development-environment.md) and that you are familiar with writing Java code.
 
-Begin by creating a class that extends `org.openrewrite.Recipe`. This recipe should accept as a configuration parameter the fully qualified name of the class to add a `hello()` method to and it should validate that parameter is configured with a valid value.
+## Outlining SayHelloRecipe
+
+Let's begin by creating a Java class that extends `org.openrewrite.Recipe`. At a minimum, this recipe should have:
+
+* An `Option` that is the fully qualified name of the class you want to add the `hello()` method to. 
+* A serializable constructor that takes in the fully qualified class name.
+* A `getDisplayName()` method that returns the display name for this recipe.
+* A `getDescription()` method that returns the description for this recipe.
+
+Here is what the class should look like with just these things defined:
 
 ```java
-package org.openrewrite.samples;
+package com.yourorg;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.openrewrite.ExecutionContext;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.internal.lang.NonNull;
-import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.tree.J;
 
+// Making your recipe immutable helps make them idempotent and eliminates a variety of possible bugs.
+// Configuring your recipe in this way also guarantees that basic validation of parameters will be done for you by rewrite.
+@Value
+@EqualsAndHashCode(callSuper = false)
 public class SayHelloRecipe extends Recipe {
-    // Making your recipe immutable helps make them idempotent and eliminates categories of possible bugs
-    // Configuring your recipe in this way also guarantees that basic validation of parameters will be done for you by rewrite
     @Option(displayName = "Fully Qualified Class Name",
-            description = "A fully-qualified class name indicating which class to add a hello() method.",
+            description = "A fully qualified class name indicating which class to add a hello() method to.",
             example = "com.yourorg.FooBar")
     @NonNull
-    private final String fullyQualifiedClassName;
-    public String getFullyQualifiedClassName() {
-        return fullyQualifiedClassName;
-    }
+    String fullyQualifiedClassName;
 
-    // Recipes must be serializable. This is verified by RecipeTest.assertChanged() and RecipeTest.assertUnchanged()
+    // All recipes must be serializable. This is verified by RewriteTest.rewriteRun() in your tests.
     @JsonCreator
     public SayHelloRecipe(@NonNull @JsonProperty("fullyQualifiedClassName") String fullyQualifiedClassName) {
         this.fullyQualifiedClassName = fullyQualifiedClassName;
@@ -71,178 +77,297 @@ public class SayHelloRecipe extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Adds a \"hello\" method to the specified class";
+        return "Adds a \"hello\" method to the specified class.";
     }
 
     // TODO: Override getVisitor() to return a JavaIsoVisitor to perform the refactoring
 }
 ```
 
-{% hint style="info" %}
-The "discover" feature of the Gradle and Maven plugins will display information from the `@Option` annotation to users of your Recipe.
-{% endhint %}
+## Writing Tests
 
-So now we have a Recipe implementation that validates that a single parameter is filled in with a non-blank value. It doesn't have any actual refactoring behavior yet, so that's what we'll add next.
+Now that we have a basic recipe defined (albeit one that doesn't _do_ anything yet), it's a good idea to write some tests. This will not only allow us to confirm that we've set everything up correctly so far, but it will also ensure that we've thought more about how this recipe will work.
 
-### Implementing the Visitor
+For our `SayHelloRecipe`, we want to ensure:
 
-To actually refactor the code in question we override `Recipe.getVisitor()` to return a new `JavaIsoVisitor<ExecutionContext>` instance that will actually perform the refactoring.
+* That a class matching the configured `fullyQualifiedClassName` with no `hello()` method will have a `hello()` method added
+* That a class that already has a different `hello()` implementation will be left untouched
+* That a class not matching the configured `fullyQualifiedClassName` with no `hello()` method will be left untouched
+
+Below is an example of what these tests might look like:
 
 ```java
-package org.openrewrite.samples;
+package com.yourorg;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Recipe;
-import org.openrewrite.internal.lang.NonNull;
-import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.tree.J;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.java.Assertions.java;
+
+class SayHelloRecipeTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new SayHelloRecipe("com.yourorg.FooBar"));
+    }
+
+    @Test
+    void addsHelloToFooBar() {
+        rewriteRun(
+            java(
+                """
+                    package com.yourorg;
+
+                    class FooBar {
+                    }
+                """,
+                """
+                    package com.yourorg;
+
+                    class FooBar {
+                        public String hello() {
+                            return "Hello from com.yourorg.FooBar!";
+                        }
+                    }
+                """
+            )
+        );
+    }
+
+    @Test
+    void doesNotChangeExistingHello() {
+        rewriteRun(
+            java(
+                """
+                    package com.yourorg;
+        
+                    class FooBar {
+                        public String hello() { return ""; }
+                    }
+                """
+            )
+        );
+    }
+
+    @Test
+    void doesNotChangeOtherClasses() {
+        rewriteRun(
+            java(
+                """
+                    package com.yourorg;
+        
+                    class Bash {
+                    }
+                """
+            )
+        );
+    }
+}
+```
+
+Please note that:
+
+* The test file implements the `RewriteTest` interface, which provides an entry point to the testing infrastructure via the method variants of `rewriteRun()`.
+* It is possible to set up defaults for all of the tests via the `defaults()` method so that you don't have to repeat the same code in each test.
+* Each test, at a minimum, will define the initial source code (the "before" state). 
+  * If there _is_ a second argument included (the "after" state), then the testing infrastructure will assert that the source file has been transformed into this new state after the recipe has been executed.
+  * If there _is not_ a second argument, then the testing infrastructure will assert that the source file has not been changed after the recipe has been executed.
+
+If you run the tests right now, you should see that the tests that expect no changes pass, whereas the test that expects changes does not. This is expected as we haven't added a visitor responsible for potentially making changes to the source code.
+
+## Implementing the visitor
+
+Now that we have a basic outline of a recipe and the tests, it's time to make the rest of our recipe.
+
+There are two main pieces to this:
+
+1. Figure out [which ASTs](/concepts-and-explanations/ast-examples.md) have the data we need to make the changes we want.
+2. Override the `Recipe.getVisitor()` method to return a visitor that is responsible for refactoring the code as desired. This visitor is where all of our core logic will live. It should ensure:
+    * That we don't change classes that don't match the specified fully qualified class name 
+    * That we don't change existing `hello()` methods. 
+    * That we _do_ add a `hello()` method to a class that matches that fully qualified class name and doesn't have an existing `hello()` method.
+
+### Figure out which ASTs are needed
+
+Before we begin writing any code, it's a good idea to figure out which ASTs contain the data we need and which ASTs we might need to change to get the results we want. Using an AST that's too broad in scope will result in us having to do much more work than necessary, but using an AST that's too narrow in scope will result in us being unable to make the changes we need to.
+
+For our use case, we care about reading class names and, potentially, changing methods inside of the class. 
+
+If we take a look at the [AST Examples doc](https://docs.openrewrite.org/concepts-and-explanations/ast-examples#ast-diagram), we can see that a [J.ClassDeclaration](https://github.com/openrewrite/rewrite/blob/v7.34.0/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java#L1062-L1336) has the information we need. It has a `FullyQualified` type that we can use to ensure we're only making changes on the specified class, and it contains a `Block` that includes `Statements` that may be `MethodDeclarations`, so we can check for a `hello()` method and potentially add one if it doesn't exist. 
+
+### Override the visitor
+
+With the knowledge of the AST we need obtained, let's make an outline of what our visitor should look like and do:
+
+```java
+// ...
 public class SayHelloRecipe extends Recipe {
-    // Making your recipe immutable helps make them idempotent and eliminates categories of possible bugs
-    // Configuring your recipe in this way also guarantees that basic validation of parameters will be done for you by rewrite
-    @Option(displayName = "Fully Qualified Class Name",
-            description = "A fully-qualified class name indicating which class to add a hello() method.",
-            example = "com.yourorg.FooBar")
-    @NonNull
-    private final String fullyQualifiedClassName;
-    public String getFullyQualifiedClassName() {
-        return fullyQualifiedClassName;
-    }
+    // ...
 
-    // Recipes must be serializable. This is verified by RecipeTest.assertChanged() and RecipeTest.assertUnchanged()
-    @JsonCreator
-    public SayHelloRecipe(@NonNull @JsonProperty("fullyQualifiedClassName") String fullyQualifiedClassName) {
-        this.fullyQualifiedClassName = fullyQualifiedClassName;
-    }
-
-    @Override
-    public String getDisplayName() {
-        return "Say Hello";
-    }
-
-    @Override
-    public String getDescription() {
-        return "Adds a \"hello\" method to the specified class";
-    }
-
-    @Override
+     @Override
     protected JavaIsoVisitor<ExecutionContext> getVisitor() {
         // getVisitor() should always return a new instance of the visitor to avoid any state leaking between cycles
         return new SayHelloVisitor();
     }
 
     public class SayHelloVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private final JavaTemplate helloTemplate =
-                JavaTemplate.builder(this::getCursor, "public String hello() { return \"Hello from #{}!\"; }")
-                        .build();
-
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
-            // TODO: Filter out classes that don't need refactoring, refactor those that do
+            // TODO: Filter out classes that don't match the fully qualified name
+
+            // TODO: Filter out classes that already have a `hello()` method
+
+            // TODO: Add a `hello()` method to classes that need it
             return classDecl;
         }
     }
 }
 ```
 
-Here we override `JavaIsoVisitor.visitClassDeclaration` in preparation for returning a modified class declaration that includes our new `hello()` method. The first step in any refactoring visit method is to _avoid refactoring_ any class which the visitor should not change. In this case, that means any class that isn't the one specified in the recipe, or any class that already has a `hello()` method. Adding this filtering to `SayHelloRecipe.SayHelloVisitor.visitClassDeclaration()` looks like this:
+Now, let's work through each of those TODOs.
+
+#### Filtering out classes that don't match the fully qualified name
+
+All of our logic lives inside of the `visitClassDeclaration` method. To filter out classes that don't match the fully qualified class name, we need to do grab some information from the `type` field in `ClassDecalaration`:
 
 ```java
-@Override
-public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
-    // In any visit() method the call to super() is what causes sub-elements of to be visited
-    J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
+// ...
+public class SayHelloRecipe extends Recipe {
+    // ...
 
-    if (classDecl.getType() == null || !classDecl.getType().getFullyQualifiedName().equals(fullyQualifiedClassName)) {
-        // We aren't looking at the specified class so return without making any modifications
-        return cd;
+    public class SayHelloVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+            // Don't make changes to classes that don't match the fully qualified name
+            if (classDecl.getType() == null || !classDecl.getType().getFullyQualifiedName().equals(fullyQualifiedClassName)) {
+                return classDecl;
+            }
+
+            // TODO: Filter out classes that already have a `hello()` method
+
+            // TODO: Add a `hello()` method to classes that need it
+            return classDecl;
+        }
     }
-
-    // Check if the class already has a method named "hello" so we don't incorrectly add a second "hello" method
-    boolean helloMethodExists = classDecl.getBody().getStatements().stream()
-            .filter(statement -> statement instanceof J.MethodDeclaration)
-            .map(J.MethodDeclaration.class::cast)
-            .anyMatch(methodDeclaration -> methodDeclaration.getName().getSimpleName().equals("hello"));
-    if (helloMethodExists) {
-        return cd;
-    }
-
-    // TODO: Use JavaTemplate to say hello()
-    return cd;
 }
 ```
 
-### Using JavaTemplate to say hello()
+#### Filtering out classes that already have a hello() method
 
-Templates are created using the `JavaTemplate.builder()` method. Within a template `#{}` is the signifier for positional parameter substitution. So to produce the hello() method add this to the visitor:
+To filter out classes that already have a `hello()` method, we need to first figure out how to check for that. A good understanding of the [ASTs](/concepts-and-explanations/ast-examples.md) is necessary for this type of filtering. With that knowledge, we can build up a stream, filter it down, and check for any matches by doing something like:
 
 ```java
-public class SayHelloVisitor extends JavaIsoVisitor<ExecutionContext> {
-    private final JavaTemplate helloTemplate =
-            JavaTemplate.builder(this::getCursor, "public String hello() { return \"Hello from #{}!\"; }")
-                    .build();
-    ...
+// ...
+public class SayHelloRecipe extends Recipe {
+    // ...
+
+    public class SayHelloVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+            // Don't make changes to classes that don't match the fully qualified name
+            if (classDecl.getType() == null || !classDecl.getType().getFullyQualifiedName().equals(fullyQualifiedClassName)) {
+                return classDecl;
+            }
+
+            // Check if the class already has a method named "hello"
+            boolean helloMethodExists = classDecl.getBody().getStatements().stream()
+                    .filter(statement -> statement instanceof J.MethodDeclaration)
+                    .map(J.MethodDeclaration.class::cast)
+                    .anyMatch(methodDeclaration -> methodDeclaration.getName().getSimpleName().equals("hello"));
+
+            // If the class already has a `hello()` method, don't make any changes to it.
+            if (helloMethodExists) {
+                return classDecl;
+            }
+
+            // TODO: Add a `hello()` method to classes that need it
+            return classDecl;
+        }
+    }
 }
 ```
 
-And use that template within `SayHelloVisitor.visitClassDeclaration` like so:
+#### Adding a hello() method to the classes that need it
+
+In order to create complex AST elements such as a new method, it's a good idea to use a [Java Template](/concepts-and-explanations/javatemplate.md). At a high-level, Java Templates simplify the creation of ASTs by converting code snippets into fully created ASTs.
+
+Templates are created using the `JavaTemplate.builder()` method. Within a template, `#{}` can be used to signify that a value will be substituted there later on. In our recipe, for instance, we don't know what the fully qualified class name is when we're compiling the program. Instead, we need to rely on the user to provide that later. 
+
+Here is what a template like that might look like for our recipe:
 
 ```java
-@Override
-public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
-    // In any visit() method the call to super() is what causes sub-elements of to be visited
-    J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
+// ...
+public class SayHelloRecipe extends Recipe {
+    // ...
 
-    if (classDecl.getType() == null || !classDecl.getType().getFullyQualifiedName().equals(fullyQualifiedClassName)) {
-        // We aren't looking at the specified class so return without making any modifications
-        return cd;
+    public class SayHelloVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private final JavaTemplate helloTemplate =
+                JavaTemplate.builder(this::getCursor, "public String hello() { return \"Hello from #{}!\"; }")
+                        .build();
+
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+            // ...
+        }
     }
-
-    // Check if the class already has a method named "hello" so we don't incorrectly add a second "hello" method
-    boolean helloMethodExists = classDecl.getBody().getStatements().stream()
-            .filter(statement -> statement instanceof J.MethodDeclaration)
-            .map(J.MethodDeclaration.class::cast)
-            .anyMatch(methodDeclaration -> methodDeclaration.getName().getSimpleName().equals("hello"));
-    if (helloMethodExists) {
-        return cd;
-    }
-
-    // Interpolate the fullyQualifiedClassName into the template and use the resulting AST to update the class body
-    cd = cd.withBody(
-            cd.getBody().withTemplate(
-                    helloTemplate,
-                    cd.getBody().getCoordinates().lastStatement(),
-                    fullyQualifiedClassName
-            ));
-
-    return cd;
 }
 ```
 
-Running this visitor on a class like `A { }` will now produce the desired result:
+We then could use that template to add a `hello()` method as desired by:
+
+```java
+// ...
+public class SayHelloRecipe extends Recipe {
+    // ...
+
+    public class SayHelloVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private final JavaTemplate helloTemplate =
+                JavaTemplate.builder(this::getCursor, "public String hello() { return \"Hello from #{}!\"; }")
+                        .build();
+
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+            // Don't make changes to classes that don't match the fully qualified name
+            if (classDecl.getType() == null || !classDecl.getType().getFullyQualifiedName().equals(fullyQualifiedClassName)) {
+                return classDecl;
+            }
+
+            // Check if the class already has a method named "hello".
+            boolean helloMethodExists = classDecl.getBody().getStatements().stream()
+                    .filter(statement -> statement instanceof J.MethodDeclaration)
+                    .map(J.MethodDeclaration.class::cast)
+                    .anyMatch(methodDeclaration -> methodDeclaration.getName().getSimpleName().equals("hello"));
+
+            // If the class already has a `hello()` method, don't make any changes to it.
+            if (helloMethodExists) {
+                return classDecl;
+            }
+
+            // Interpolate the fullyQualifiedClassName into the template and use the resulting AST to update the class body
+            classDecl = classDecl.withBody(
+                    classDecl.getBody().withTemplate(
+                            helloTemplate,
+                            classDecl.getBody().getCoordinates().lastStatement(),
+                            fullyQualifiedClassName
+                    ));
+
+            return classDecl;
+        }
+    }
+}
+```
+
+## Completed visitor
+
+With all of that done, the complete `SayHelloRecipe` looks like this:
 
 ```java
 package com.yourorg;
 
-class A {
-    public String hello() {
-        return "Hello from com.yourorg.A!";
-    }
-
-}
-```
-
-So the complete `SayHelloRecipe` looks like this:
-
-```java
-package org.openrewrite.samples;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
@@ -251,19 +376,18 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.tree.J;
 
+// Making your recipe immutable helps make them idempotent and eliminates categories of possible bugs.
+// Configuring your recipe in this way also guarantees that basic validation of parameters will be done for you by rewrite.
+@Value
+@EqualsAndHashCode(callSuper = false)
 public class SayHelloRecipe extends Recipe {
-    // Making your recipe immutable helps make them idempotent and eliminates categories of possible bugs
-    // Configuring your recipe in this way also guarantees that basic validation of parameters will be done for you by rewrite
     @Option(displayName = "Fully Qualified Class Name",
-            description = "A fully-qualified class name indicating which class to add a hello() method.",
+            description = "A fully qualified class name indicating which class to add a hello() method to.",
             example = "com.yourorg.FooBar")
     @NonNull
-    private final String fullyQualifiedClassName;
-    public String getFullyQualifiedClassName() {
-        return fullyQualifiedClassName;
-    }
+    String fullyQualifiedClassName;
 
-    // Recipes must be serializable. This is verified by RecipeTest.assertChanged() and RecipeTest.assertUnchanged()
+    // All recipes must be serializable. This is verified by RewriteTest.rewriteRun() in your tests.
     @JsonCreator
     public SayHelloRecipe(@NonNull @JsonProperty("fullyQualifiedClassName") String fullyQualifiedClassName) {
         this.fullyQualifiedClassName = fullyQualifiedClassName;
@@ -276,7 +400,7 @@ public class SayHelloRecipe extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Adds a \"hello\" method to the specified class";
+        return "Adds a \"hello\" method to the specified class.";
     }
 
     @Override
@@ -292,133 +416,69 @@ public class SayHelloRecipe extends Recipe {
 
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
-            // In any visit() method the call to super() is what causes sub-elements of to be visited
-            J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
-
+            // Don't make changes to classes that don't match the fully qualified name
             if (classDecl.getType() == null || !classDecl.getType().getFullyQualifiedName().equals(fullyQualifiedClassName)) {
-                // We aren't looking at the specified class so return without making any modifications
-                return cd;
+                return classDecl;
             }
 
-            // Check if the class already has a method named "hello" so we don't incorrectly add a second "hello" method
+            // Check if the class already has a method named "hello".
             boolean helloMethodExists = classDecl.getBody().getStatements().stream()
                     .filter(statement -> statement instanceof J.MethodDeclaration)
                     .map(J.MethodDeclaration.class::cast)
                     .anyMatch(methodDeclaration -> methodDeclaration.getName().getSimpleName().equals("hello"));
+
+            // If the class already has a `hello()` method, don't make any changes to it.
             if (helloMethodExists) {
-                return cd;
+                return classDecl;
             }
 
             // Interpolate the fullyQualifiedClassName into the template and use the resulting AST to update the class body
-            cd = cd.withBody(
-                    cd.getBody().withTemplate(
+            classDecl = classDecl.withBody(
+                    classDecl.getBody().withTemplate(
                             helloTemplate,
-                            cd.getBody().getCoordinates().lastStatement(),
+                            classDecl.getBody().getCoordinates().lastStatement(),
                             fullyQualifiedClassName
                     ));
 
-            return cd;
+            return classDecl;
         }
     }
 }
 ```
 
-## Testing
+If you run the tests, they should all pass. Running this recipe on a class like `FooBar { }` should now produce the desired result:
 
-To create automated tests of this visitor we use the [Kotlin](https://kotlinlang.org/) language, mostly for convenient access to multi-line Strings, with [JUnit 5](https://junit.org/junit5/docs/current/user-guide/) and using a fluent testing API that is provided by the rewrite-test module.
+```java
+package com.yourorg;
 
-For `SayHelloRecipe` it is sensible to test:
-
-* That a class matching the configured `fullyQualifiedClassName` with no `hello()` method will have a `hello()` method added
-* That a class that already has a different `hello()` implementation will be left untouched
-* That a class not matching the configured `fullyQualifiedClassName` with no `hello()` method will be left untouched
-
-The test for the recipe will implement the `RewriteTest` interface that provides the entry point to the testing infrastructure via the method variants of `rewriteRun().` Our test will override the `defaults(RecipeSpec)`method and define both the recipe and the Java parser configuration that will be shared by all three of the tests.\
-\
-Each test will define a Java `SourceSpec` that, at a minimum, will define the initial source code (the "before" state) for each test. If a second argument is excluded from a source specification, the testing infrastructure will assert that no changes are made to the given source file. If a second argument (the "after" state) is defined for a test, the testing infrastructure will assert that the source file has been transformed correctly after the recipe has been executed.
-
-
-
-```kotlin
-package org.openrewrite.samples
-
-import org.junit.jupiter.api.Test
-import org.openrewrite.java.Assertions.java
-import org.openrewrite.test.RecipeSpec
-import org.openrewrite.test.RewriteTest
-
-class SayHelloRecipeTest: RewriteTest {
-
-    override fun defaults(spec: RecipeSpec) {
-        spec
-            .recipe(SayHelloRecipe("com.yourorg.A"))
+class FooBar {
+    public String hello() {
+        return "Hello from com.yourorg.FooBar!";
     }
-
-    @Test
-    fun addsHelloToA() = rewriteRun(
-        java(
-            """
-                package com.yourorg;
-    
-                class A {
-                }
-            """,
-            """
-                package com.yourorg;
-    
-                class A {
-                    public String hello() {
-                        return "Hello from com.yourorg.A!";
-                    }
-                }
-            """
-        )
-    )
-
-    @Test
-    fun doesNotChangeExistingHello() = rewriteRun(
-        java(
-            """
-                package com.yourorg;
-    
-                class A {
-                    public String hello() { return ""; }
-                }
-            """
-        )
-    )
-
-    @Test
-    fun doesNotChangeOtherClass() = rewriteRun(
-        java(
-            """
-                package com.yourorg;
-    
-                class B {
-                }
-            """
-        )
-    )
 }
 ```
 
-{% hint style="success" %}
-Users of [IntelliJ Idea](https://www.jetbrains.com/idea/) benefit from Java syntax highlighting when authoring these tests.
-{% endhint %}
-
 ## Declarative YAML Usage
 
-`SayHelloRecipe` is now ready to be used in code or declaratively from YAML.
+`SayHelloRecipe` is now ready to be used in code or declaratively from YAML:
 
 {% tabs %}
 {% tab title="YAML" %}
 ```yaml
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: com.yourorg.sayHelloA
+name: com.yourorg.sayHelloToFooBar
 recipeList:
   - org.openrewrite.samples.SayHelloRecipe:
-      fullyQualifiedClassName: com.yourorg.A
+      fullyQualifiedClassName: com.yourorg.FooBar
 ```
 {% endtab %}
 {% endtabs %}
+
+## Next Steps
+
+Congratulations on finishing your first recipe! Before you begin making your own recipe, please consider checking out these other docs:
+
+* [A deeper look into testing](/tutorials/authoring-recipes/recipe-testing.md)
+* [A best practice guide for making recipes](/tutorials/authoring-recipes/recipe-conventions-and-best-practices.md)
+* [A more complex recipe creation tutorial](/tutorials/authoring-recipes/modifying-methods-with-javatemplate.md)


### PR DESCRIPTION
This addresses a lot of issues with this tutorial such as:
* Many parts of the code were wrong or unneeded
* Kotlin was being used and encouraged when it shouldn't be
* There was not enough context for people to understand certain topics
* Some hints or comments were incorrect
