### PR TITLE
Rewrite the recipe testing guide

### DIFF
--- a/authoring-recipes/writing-a-java-refactoring-recipe.md
+++ b/authoring-recipes/writing-a-java-refactoring-recipe.md
@@ -92,6 +92,10 @@ If you don't use Lombok's `@Value` annotation, it will be up to you to ensure th
 
 Now that we have a basic recipe defined (albeit one that doesn't _do_ anything yet), it's a good idea to write some tests. This will not only allow us to confirm that we've set everything up correctly so far, but it will also ensure that we've thought more about how this recipe will work.
 
+{% hint style="info" %}
+For a more extensive look into recipe testing, check out the [Recipe Testing Guide](/authoring-recipes/recipe-testing.md)
+{% endhint %}
+
 For our `SayHelloRecipe`, we want to ensure:
 
 * That a class matching the configured `fullyQualifiedClassName` with no `hello()` method will have a `hello()` method added


### PR DESCRIPTION
This rewrite does a few things:
* It removes lots of Kotlin code in favor of Java code
* It breaks the guide up into smaller, more understandable components
* It uses more welcoming and friendly language
* It fixes a variety of spelling and grammar errors