### PR TITLE
Rewrite declarative YAML format doc

### DIFF
--- a/concepts-and-explanations/recipes.md
+++ b/concepts-and-explanations/recipes.md
@@ -102,6 +102,10 @@ recipeList:
   - org.example.testing.AddJUnitDependencies
 ```
 
+{% hint style="info" %}
+For more information on how to work with and use declarative recipes, please read our [Declarative YAML guide](/reference/yaml-format-reference.md).
+{% endhint %}
+
 ## Recipe Configuration & Validation
 
 OpenRewrite provides a managed environment in which a set of recipes are executed. It will instantiate recipe instances and often inject configuration properties that have been defined within configuration files. The Recipe class exposes a `validate()` method that is called by the framework to determine whether all required configuration to a recipe has been supplied. The default implementation of `validate()` provides basic required/optional validation checks if a recipe's fields are annotated with `@NonNull`.

--- a/concepts-and-explanations/styles.md
+++ b/concepts-and-explanations/styles.md
@@ -74,6 +74,10 @@ styleConfigs:
   </tbody>
 </table>
 
+{% hint style="info" %}
+For more information on how to work with and use declarative styles, please read our [Declarative YAML guide](/reference/yaml-format-reference.md#styles).
+{% endhint %}
+
 ## Next Steps
 
 In [Environment](environment.md), we'll see how these styles are activated and applied to the parsers that consume code. It will also show how to discover and activate recipes of visitors.

--- a/reference/yaml-format-reference.md
+++ b/reference/yaml-format-reference.md
@@ -1,88 +1,117 @@
----
-description: Declaring and configuring Recipes and Styles in YAML
----
-
 # Declarative YAML format
 
-There are two places OpenRewrite [YAML](https://yaml.org) files may appear:
+OpenRewrite allows you to create [recipes](/concepts-and-explanations/recipes.md) and [styles](/concepts-and-explanations/styles.md) in [YAML](https://yaml.org). While doing so potentially reduces customizability, it makes up for that with development speed and portability.
 
-* Within the rewrite.yml file of a project that applies rewrite recipes via the [rewrite-gradle-plugin](gradle-plugin-configuration.md) or [rewrite-maven-plugin](rewrite-maven-plugin.md)
-  * Will not be included in jars published from your project
-* Inside the META-INF/rewrite folder of a jar
-  * Put your recipes here if you want to redistribute and apply them to other repositories
-  * See [Recipe Development Environment](../authoring-recipes/recipe-development-environment.md) for instructions on setting up your project for recipe development
-  * e.g.: [rewrite-testing-frameworks](https://github.com/openrewrite/rewrite-testing-frameworks/tree/master/src/main/resources/META-INF/rewrite)
+To help you confidently define recipes and styles in YAML, this guide will walk you through all of the ways you can configure an OpenRewrite YAML file.
 
-In either case, these YAML files share the same format and purpose: making styles and recipes available to rewrite. A single OpenRewrite YAML file may contain any number of recipes and styles, separated by `---`.
+## Where OpenRewrite YAML files can exist
 
-{% hint style="info" %}
-Within a YAML document recipe and style names are always fully qualified.
-{% endhint %}
+There are two places where you can define an OpenRewrite YAML file:
 
-{% hint style="warning" %}
-Don't place your custom recipes into the org.openrewrite namespace. We recommend using the same "reverse domain name" naming scheme used in Java packages.
-{% endhint %}
+1. Within the `rewrite.yml` file of a project that applies rewrite recipes via the [rewrite-gradle-plugin](gradle-plugin-configuration.md) or [rewrite-maven-plugin](rewrite-maven-plugin.md)
+2. Inside the `META-INF/rewrite` folder of a jar (such as in the [rewrite-testing-frameworks](https://github.com/openrewrite/rewrite-testing-frameworks/tree/master/src/main/resources/META-INF/rewrite))
+
+If you define a recipe or style in the `rewrite.yml` file, they _will not_ be included in the jars published from your project.
+
+If you want to redistribute a recipe or a style and apply them to other projects, you'll need to create them inside of the `META-INF/rewrite` folder of a jar.
+
+## Best practices
+
+Please keep these conventions in mind when you're creating OpenRewrite YAML files:
+
+* A file may contain any number of recipes and styles, separated by `---`.
+* Within a file, recipe and style names must be fully qualified.
+* Custom recipes should not be placed into the `org.openrewrite` namespaced. Instead, they should follow the same [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) used in Java packages. 
 
 ## Recipes
 
-The basic format of a recipe defined in YAML is:
+### Format
 
-```yaml
----
-type: specs.openrewrite.org/v1beta/recipe
-name: com.yourorg.RecipeA     # A fully qualified, unique name for this recipe
-displayName: Recipe A         # A human-readable name for this recipe
-description: Applies Recipe B # A human-readable description for this recipe
-recipeList:                   # the list of recipes which comprise this recipe
-  - com.yourorg.RecipeB:      # A fully qualified name for a recipe defined elsewhere
-      exampleConfig: foo      # A configurable parameter of RecipeB
-```
+| Key                         | Type             | Description                                                             |
+|-----------------------------|------------------|-------------------------------------------------------------------------|
+| type                        | const            | A constant:  `specs.openrewrite.org/v1beta/recipe`                      |
+| name                        | string           | A fully qualified, unique name for this recipe                          |
+| displayName                 | string           | A human-readable name for this recipe                                   |
+| description                 | string           | A human-readable description for this recipe                            |
+| tags                        | array of strings | A list of strings that help categorize this recipe                      |
+| estimatedEffortPerOccurence | [duration](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-)         | The expected amount of time saved each time this recipe fixes something |
+| causesAnotherCycle          | boolean          | Whether or not this recipe can cause another cycle (defaults to false)  |
+| applicability               | object           | The list of [applicability tests](#applicability-tests) for this recipe                         |
+| ↪ singleSource              | array of recipes | See [applicability tests](#applicability-tests)                                                 |
+| ↪ anySource                 | array of recipes | See [applicability tests](#applicability-tests)                                                 |
+| [recipeList](#recipe-list)                  | array of recipes | The list of recipes which comprise this recipe                          |
 
-Consider this example declarative recipe which uses the built-in `ChangeMethodName` and `ChangePackage` recipes to rename a method and a package.
+### Applicability tests
 
-{% code title="rewrite.yml" %}
-```yaml
----
-type: specs.openrewrite.org/v1beta/recipe
-name: com.yourorg.SayHello
-recipeList:
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.yourorg.HelloWorld sayGoodbye()
-      newMethodName: sayHello
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: com.yourorg.goodbye
-      newPackageName: com.yourorg.hello
-```
-{% endcode %}
+As mentioned in our [best practices guide](/authoring-recipes/recipe-conventions-and-best-practices.md#use-applicability-tests), it's a good idea to add applicability tests to your recipes. These tests limit where your recipe is run so that it can be run faster and so it's clearer to others what it does.
 
-To run this recipe:
+While most of the recipes that comprise a declarative recipe have their own applicability tests, you can add a new layer of applicability tests on top of those. These tests will be run before any individual recipe runs its applicability tests. If any of these top-level tests fail, the recipes in the `recipeList` will not run. If these top-level tests pass, then the declarative recipe will begin iterating through the recipes in the `recipeList`. Each recipe in that list will run its own applicability tests before performing any refactoring.
 
-1. Put the above into a rewrite.yml file at the project root
-2. Configure the [gradle plugin](gradle-plugin-configuration.md) or [maven plugin](rewrite-maven-plugin.md) with `com.yourorg.SayHello` listed as an active recipe
-3. Run the "rewrite:run" maven goal or "rewriteRun" gradle task
+To create these top-level applicability tests, you'll need to add the `applicability` object to your file. This object has two pieces: `singleSource` and `anySource`. Each of those is composed of one or more recipes (formatted the same way as the [recipeList](#recipe-list)).
+
+If the `singleSource` list is specified, OpenRewrite will grab a file from the repository the recipe is being run on. It will then run each recipe in the `singleSource` section on that file. If _all_ of those recipes result in a change to that file, then the declarative recipe is considered "applicable" for that file and the recipes specified in the `recipeList` will be run on said file. Once that's done, the process will be repeated for the next file in the repository.
+
+If the `anySource` list is specified, OpenRewrite will run every recipe in the `anySource` list on every file in the repository the recipe is being run on. If _any_ of those recipes result in a change to at least one file, then the declarative recipe is considered "applicable" for that repository and the recipes specified in the `recipeList` will be run on every file in the repository.
+
+You can specify both `singleSource` and `anySource` applicability tests in a declarative recipe.
+
+### Recipe list
+
+A declarative recipe can be made up of one or more recipes. The recipes in the list could be other declarative recipes defined in the same file or they can be imperative recipes created elsewhere. Like imperative recipes, each recipe in this list can potentially have configuration options that need to be specified.
 
 {% hint style="success" %}
-Order of recipe declaration is not important. A declarative recipe may include another declarative recipe declared later in the same file in its recipeList.
+Order of recipe declaration is not important. A declarative recipe may include another declarative recipe declared later in the same file in its `recipeList`.
 {% endhint %}
+
+### Recipe example
+
+Consider this example declarative recipe:
+
+```yaml
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.yourorg.RecipeA
+displayName: Recipe A
+description: Applies Recipe B
+tags:
+  - tag1
+  - tag2
+estimatedEffortPerOccurrence: PT15M
+causesAnotherCycle: true
+applicability:
+  singleSource:
+    - org.openrewrite.FindSourceFiles:
+      filePattern: '**/hello.txt'
+  anySource:
+    - org.openrewrite.gradle.search.FindPlugins:
+      pluginId: com.gradle.build-scan
+recipeList:
+  - com.yourorg.RecipeB:
+      exampleConfig1: foo
+      exampleConfig2: bar
+  - com.yourorg.RecipeC
+```
+
+If you wanted to run this recipe (but not redistribute it to others), you would:
+
+1. Copy the above YAML into a `rewrite.yml` file at the root of your project
+2. Configure the [Gradle plugin](gradle-plugin-configuration.md) or [Maven plugin](rewrite-maven-plugin.md) to have an active recipe of `com.yourorg.RecipeA`
+3. Run the `./mvnw rewrite:run` or the `/.gradlew rewriteRun` command
 
 ## Styles
 
-The basic format of a Style defined in YAML is:
+### Format
 
-```yaml
----
-type: specs.openrewrite.org/v1beta/style
-name: com.yourorg.StyleA # A fully qualified, unique name for this style
-displayName: Style A     # A human-readable name for this style
-description: Applies B   # A human-readable description for this style
-styleConfigs:            # The list of styles which comprise this style
-  - com.yourorg.StyleB:  # The fully qualified name for a style defined elsewhere
-      exampleConfig: foo # A configurable parameter of StyleB
-```
+| Key          | Type             | Description                                       |
+|--------------|------------------|---------------------------------------------------|
+| type         | const            | A constant:  `specs.openrewrite.org/v1beta/style` |
+| name         | string           | A fully qualified, unique name for this style     |
+| displayName  | string           | A human-readable name for this style              |
+| description  | string           | A human-readable description for this style       |
+| tags         | array of strings | A list of strings that help categorize this style |
+| styleConfigs | array of styles  | The list of styles which comprise this style      |
 
-{% hint style="warning" %}
-While you can define whatever sort of styles you may want, the formatting recipes built into OpenRewrite itself know how to act upon styles built into OpenRewrite. A full reference for such styles will be added to this documentation soon.
-{% endhint %}
+### Style example
 
 Consider this example declarative style, which specifies that tabs should be used for indentation and that at least 9999 imports from a given package should be required before collapsing them into a single star import:
 
@@ -99,7 +128,7 @@ styleConfigs:
 
 To put this style in effect for any formatting performed by OpenRewrite within the current project:
 
-1. Put the above into a rewrite.yml file at the project root
+1. Put the above into a `rewrite.yml` file at the project root
 2. Configure the [gradle plugin](gradle-plugin-configuration.md) or [maven plugin](rewrite-maven-plugin.md) with `com.yourorg.YesTabsNoStarImports` listed as the active style
 
-The next time any OpenRewrite recipe is run any formatting it performs will take these styles into account.
+The next time any OpenRewrite recipe is run in that project, any formatting it performs will take these styles into account.


### PR DESCRIPTION
* Adds tables to explicitly show all supported keys and their descriptions
* Adds an explanation of applicability tests and how to use them in recipes
* Resolves issue: https://github.com/openrewrite/rewrite-docs/issues/132
* Simplifies a few confusing blurbs