### PR TITLE
Document method pattern varargs examples

### DIFF
--- a/reference/method-patterns.md
+++ b/reference/method-patterns.md
@@ -29,21 +29,27 @@ The return type of a method is _not_ represented in method patterns. Methods in 
 
 ### Examples
 
-So if you wanted to match invocations of `String.toString(int beginIndex)` then this expression would match only that method: `java.lang.String toString(int)`. If you wanted to match the two-argument form of the same
+So if you wanted to match invocations of `String.substring(int beginIndex)` then this expression would match only that method: `java.lang.String substring(int)`.
+If you wanted to match the two-argument form of the same, you can use the method pattern `java.lang.String substring(int, int)`.
+The below table shows some more examples of method patterns and the methods they match.
 
-| Method Pattern                              | Matches                                                                                                                                                                                              |
-|:--------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `java.lang.String substring(int)`           | Exactly the [single argument overload](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#substring%28int%29) of `String.substring()`                                |
-| `java.lang.String substring(int, int)`      | Exactly the [two argument overload](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#substring%28int,int%29) of `String.substring()`                               |
-| `java.lang.String substring(..)`            | Any overload of `String.substring()`                                                                                                                                                                 |
-| `java.lang.String *(int)`                   | Any method on `String` that accepts a single argument of type `int`                                                                                                                                  |
-| `java.lang.String format(String, ..)`       | Exactly the [String.format(String, Object...)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#format(java.lang.String,java.lang.Object...)) method with varargs. |
-| `java.lang.String format(String, Object[])` | Exactly the [String.format(String, Object...)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#format(java.lang.String,java.lang.Object...)) method with varargs. |
-| `com.yourorg.Foo bar(int, String, ..)`      | Any method on `Foo` named `bar` accepting an `int`, a `String`, and zero or more other arguments of any type                                                                                         |
-| `com.yourorg.Foo <constructor>(*, *, *)`    | Constructors of `Foo` accepting exactly three arguments of any type.                                                                                                                                 |
-| `*..String *(..)`                           | Any method accepting any arguments on classes named "String" in any package                                                                                                                          |
-| `*..* *(..)`                                | Any method accepting any arguments on any class                                                                                                                                                      |
-| `org.example..* *(..)`                      | Any method on any class in the "org.example" package, or any sub-package of "org.example"                                                                                                            |
+| Method Pattern                              | Matches                                                                                                                                                                                                         |
+|:--------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `java.lang.String substring(int)`           | Exactly the [single argument overload](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#substring%28int%29) of `String.substring(int beginIndex)`                             |
+| `java.lang.String substring(int, int)`      | Exactly the [two argument overload](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#substring%28int,int%29) of `String.substring(int beginIndex, int endIndex)`              |
+| `java.lang.String substring(..)`            | Any overload of `String.substring()` with any number of arguments                                                                                                                                               |
+| `java.lang.String *(int)`                   | Any method on `String` that accepts a single argument of type `int`                                                                                                                                             |
+| `java.lang.String format(String, ..)`       | Exactly the [String.format(String format, Object... args)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#format(java.lang.String,java.lang.Object...)) method with varargs |
+| `java.lang.String format(String, Object[])` | Exactly the [String.format(String format, Object... args)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#format(java.lang.String,java.lang.Object...)) method with varargs |
+| `com.yourorg.Foo bar(int, String, ..)`      | Any method on `Foo` named `bar` accepting an `int`, a `String`, and zero or more other arguments of any type                                                                                                    |
+| `com.yourorg.Foo <constructor>(*, *, *)`    | Constructors of `Foo` accepting exactly three arguments of any type                                                                                                                                             |
+| `*..String *(..)`                           | Any method accepting any arguments on classes named "String" in any package                                                                                                                                     |
+| `*..* *(..)`                                | Any method accepting any arguments on any class                                                                                                                                                                 |
+| `org.example..* *(..)`                      | Any method on any class in the "org.example" package, or any sub-package of "org.example"                                                                                                                       |
+
+{% hint style="info" %}
+When matching methods using varags, method patterns should match the parameter _declaration_, not the parameter _use_ for method invocations.
+{% endhint %}
 
 ## Usage
 

--- a/reference/method-patterns.md
+++ b/reference/method-patterns.md
@@ -31,17 +31,19 @@ The return type of a method is _not_ represented in method patterns. Methods in 
 
 So if you wanted to match invocations of `String.toString(int beginIndex)` then this expression would match only that method: `java.lang.String toString(int)`. If you wanted to match the two-argument form of the same
 
-| Method Pattern | Matches |
-| :--- | :--- |
-| `java.lang.String substring(int)` | Exactly the [single argument overload](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#substring%28int%29) of `String.substring()` |
-| `java.lang.String substring(int, int)` | Exactly the [two argument overload](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#substring%28int,int%29) of `String.substring()` |
-| `java.lang.String substring(..)` | Any overload of `String.substring()` |
-| `java.lang.String *(int)` | Any method on `String` that accepts a single argument of type `int` |
-| `com.yourorg.Foo bar(int, String, ..)` | Any method on `Foo` named `bar` accepting an `int`, a `String`, and zero or more other arguments of any type |
-| `com.yourorg.Foo <constructor>(*, *, *)` | Constructors of `Foo` accepting exactly three arguments of any type. |
-| `*..String *(..)` | Any method accepting any arguments on classes named "String" in any package |
-| `*..* *(..)` | Any method accepting any arguments on any class |
-| `org.example..* *(..)` | Any method on any class in the "org.example" package, or any sub-package of "org.example" |
+| Method Pattern                              | Matches                                                                                                                                                                                              |
+|:--------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `java.lang.String substring(int)`           | Exactly the [single argument overload](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#substring%28int%29) of `String.substring()`                                |
+| `java.lang.String substring(int, int)`      | Exactly the [two argument overload](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#substring%28int,int%29) of `String.substring()`                               |
+| `java.lang.String substring(..)`            | Any overload of `String.substring()`                                                                                                                                                                 |
+| `java.lang.String *(int)`                   | Any method on `String` that accepts a single argument of type `int`                                                                                                                                  |
+| `java.lang.String format(String, ..)`       | Exactly the [String.format(String, Object...)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#format(java.lang.String,java.lang.Object...)) method with varargs. |
+| `java.lang.String format(String, Object[])` | Exactly the [String.format(String, Object...)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#format(java.lang.String,java.lang.Object...)) method with varargs. |
+| `com.yourorg.Foo bar(int, String, ..)`      | Any method on `Foo` named `bar` accepting an `int`, a `String`, and zero or more other arguments of any type                                                                                         |
+| `com.yourorg.Foo <constructor>(*, *, *)`    | Constructors of `Foo` accepting exactly three arguments of any type.                                                                                                                                 |
+| `*..String *(..)`                           | Any method accepting any arguments on classes named "String" in any package                                                                                                                          |
+| `*..* *(..)`                                | Any method accepting any arguments on any class                                                                                                                                                      |
+| `org.example..* *(..)`                      | Any method on any class in the "org.example" package, or any sub-package of "org.example"                                                                                                            |
 
 ## Usage
 

--- a/reference/method-patterns.md
+++ b/reference/method-patterns.md
@@ -29,8 +29,6 @@ The return type of a method is _not_ represented in method patterns. Methods in 
 
 ### Examples
 
-So if you wanted to match invocations of `String.substring(int beginIndex)` then this expression would match only that method: `java.lang.String substring(int)`.
-If you wanted to match the two-argument form of the same, you can use the method pattern `java.lang.String substring(int, int)`.
 The below table shows some more examples of method patterns and the methods they match.
 
 | Method Pattern                              | Matches                                                                                                                                                                                                         |

--- a/reference/method-patterns.md
+++ b/reference/method-patterns.md
@@ -47,6 +47,12 @@ The below table shows some more examples of method patterns and the methods they
 
 {% hint style="info" %}
 When matching methods using varags, method patterns should match the parameter _declaration_, not the parameter _use_ for method invocations.
+So for example, the method pattern `String.format(String, Object[])` would match all of these method invocations, regardless of the number of varargs parameters actually passed:
+```java
+String.format("Foo bar");
+String.format("%s bar", "Foo");
+String.format("%s %s", "Foo", "bar");
+```
 {% endhint %}
 
 ## Usage


### PR DESCRIPTION
This came up while working on a recipe that tried to match a specific invocation with two arguments, of a method that takes a variable number of arguments in https://github.com/openrewrite/rewrite/issues/2859#issuecomment-1435650842 . Figured document the case in the table so there's no confusion about matching method invocations.