### PR TITLE
Change Migrate to Java 17 page, code before/after to be shown on the page at the same time instead of tabs

### DIFF
--- a/running-recipes/popular-recipe-guides/migrate-to-java-17.md
+++ b/running-recipes/popular-recipe-guides/migrate-to-java-17.md
@@ -74,8 +74,9 @@ At this point, you're ready to execute the migration by running `mvn rewrite:run
 
 For the complete list of changes made by this recipe, please see the reference pages for [Java 11](../../reference/recipes/java/migrate/java8tojava11.md) and [Java 17](../../reference/recipes/java/migrate/upgradetojava17.md). If you have a specific use case that is not yet covered by this project, please reach out to our team!
 
-{% tabs %}
-{% tab title="Example Class (Before)" %}
+### Example Class 
+#### Before
+
 ```java
 package org.openrewrite.example;
 
@@ -104,9 +105,9 @@ public class Example {
     }
 }
 ```
-{% endtab %}
 
-{% tab title="Example Class (After)" %}
+#### After
+
 ```java
 package org.openrewrite.example;
 
@@ -135,15 +136,14 @@ public class Example {
     }    
 }
 ```
-{% endtab %}
-{% endtabs %}
 
 {% hint style="info" %}
 The above example class demonstrates the two most common code migration tasks when moving to Java 11. There are many additional tasks covered by this recipe that are not represented in this example.&#x20;
 {% endhint %}
 
-{% tabs %}
-{% tab title="Maven pom (Before)" %}
+### Maven pom
+
+#### Before
 ```markup
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -181,9 +181,7 @@ The above example class demonstrates the two most common code migration tasks wh
     </dependencies>
 </project>
 ```
-{% endtab %}
-
-{% tab title="Maven pom (After)" %}
+#### After
 ```markup
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -234,8 +232,6 @@ The above example class demonstrates the two most common code migration tasks wh
     </dependencies>
 </project>
 ```
-{% endtab %}
-{% endtabs %}
 
 {% hint style="info" %}
 The JAXB and JAX-WS dependencies will only be added to the project if types from those projects are detected.


### PR DESCRIPTION
Update `Migrate to Java 17` page, Change code before/after to be shown on the page at the same time instead of tabs.
Because of this way, people can view and compare the difference clearly. 
And also, sometimes when switching tabs, the page scrolls up or down due to an unknown reason (maybe browser's problem), but display them on same page doesn't have this problem.

Before
<img width="963" alt="Screen Shot 2023-03-28 at 5 26 33 PM" src="https://user-images.githubusercontent.com/122563761/228395844-faf0b78f-66fb-4252-b5eb-8c7ac5b9464b.png">

Now (ignore the color difference since it's rendered by different tools)
![Screen Shot 2023-03-28 at 5 27 13 PM](https://user-images.githubusercontent.com/122563761/228395913-0075d9df-8e49-468d-87fb-328106f7a449.png)
