### PR TITLE
Ignore drafts for check-spelling

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -69,6 +69,7 @@ on:
     - 'opened'
     - 'reopened'
     - 'synchronize'
+    - 'ready_for_review'
   issue_comment:
     types:
     - 'created'
@@ -84,7 +85,7 @@ jobs:
     outputs:
       followup: ${{ steps.spelling.outputs.followup }}
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event_name, 'pull_request') || github.event_name == 'push' }}
+    if: ${{ (contains(github.event_name, 'pull_request') && github.event.pull_request.draft == false) || github.event_name == 'push' }}
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
@@ -131,6 +132,7 @@ jobs:
         github.repository_owner != 'openrewrite' &&
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
+        github.event.pull_request.draft == false &&
         contains(github.event.comment.body, '@check-spelling-bot apply')
       }}
     concurrency:


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Check Spelling will not perform checks for pull-requests while they're in draft state.

There are two sides to this:
1. An additional `if:` condition for `github.event.pull_request.draft == false` -- this suppresses checks while the PR is in draft (note that any initial `push` events will still run and may trigger scanning / reporting if it's unhappy, but subsequent runs once a PR is opened will be suppressed by check-spelling's `suppress_push_for_open_pull_request`)
2. `on:` / `pull_request_target:` / `types:` / `'ready_for_review'` -- this triggers a check when someone converts the PR from draft to ready for review (otherwise you'd have to wait for an additional push, which would be frustrating).

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
@mike-solomon asked to avoid being told about spelling while his PR (#167) was in draft

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
