### PR TITLE
Polish "Running Rewrite on a Gradle project without modifying the build" guide

### DIFF
--- a/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build.md
+++ b/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build.md
@@ -10,7 +10,7 @@ To have a reproducible example, we'll start with a repository generated from [Sp
 
 ### Step 2: Create a Gradle init script.
 
-Save the following init script. It does not need to be in the project directory itself. In the `allprojects` block, we are specifying a dependency that contains OpenRewrite recipes (`rewrite-java`), and are also configuring a custom recipe YAML for use. For the full range of options, see [Gradle Plugin Configuration](/reference/gradle-plugin-configuration.md).
+Save the following init script. It does not need to be in the project directory itself. In the `rootProject` block, we are specifying a dependency that contains OpenRewrite recipes (`rewrite-java`), and are also configuring a custom recipe YAML for use. For the full range of options, see [Gradle Plugin Configuration](/reference/gradle-plugin-configuration.md).
 
 ```groovy
 initscript {


### PR DESCRIPTION
Initscript uses `rootProject` rather than `allprojects`. Additionally, rewrite declarative recipe is actually required and not optional for the guide.