### PR TITLE
Suggest disabling GPG signed commits to allow build to pass

### DIFF
--- a/reference/building-openrewrite-from-source.md
+++ b/reference/building-openrewrite-from-source.md
@@ -8,6 +8,8 @@ OpenRewrite requires several JDK versions to be installed on your system. If you
 
 To compile and run tests invoke `./gradlew build`. To publish a snapshot build to your maven local repository, run `./gradlew publishToMavenLocal`.
 
+> **Note** If some of your tests fail with a message like `java.lang.IllegalArgumentException: Invalid value: gpg.format=ssh`, try running `git config commit.gpgsign false` in the `rewrite` directory to disable GPG signing for your commits then re-run the build. This is because there are some tests that use the [JGit](https://projects.eclipse.org/projects/technology.jgit) library to run git commands, which at the time of writing does not support SSH-based signed commits. See [this bug](https://bugs.eclipse.org/bugs/show_bug.cgi?id=581483) for more information.
+
 ### Building within Secure/Isolated environments
 
 OpenRewrite typically accesses the Maven Central artifact repository to download necessary dependencies. If organizational security policy or network configuration forbids this, then you can use a Gradle [init script](https://docs.gradle.org/current/userguide/init\_scripts.html) to forcibly reconfigure the OpenRewrite build to use a different repository.


### PR DESCRIPTION
Add instructions to disable signed commits in the rewrite repository if necessary because JGit does not currently have support for SSH format GPG signatures.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Added a suggestion to the "building from source" page to disable GPG signed commits in the repo, in case you are using SSH format GPG signed commits globally, which JGit does not currently support.

## What's your motivation?

Make it easier for people to build OpenRewrite from source without running into mysterious test errors related to their git configuration.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?

Yes, disable GPG signed commits globally, but this may not be an option or the most convenient option for most people because they would like to sign their commits elsewhere.

I looked into upgrading JGit but not even `master` supports the SSH format. See [GpgConfig.java](https://git.eclipse.org/r/plugins/gitiles/jgit/jgit/+/refs/heads/master/org.eclipse.jgit/src/org/eclipse/jgit/lib/GpgConfig.java#22) for more information, or [this bug](https://bugs.eclipse.org/bugs/show_bug.cgi?id=581483).

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
