### PR TITLE
Use latest version of org.openrewrite.maven

### DIFF
--- a/running-recipes/popular-recipe-guides/migrate-to-spring-3.md
+++ b/running-recipes/popular-recipe-guides/migrate-to-spring-3.md
@@ -15,7 +15,7 @@ The [Spring 3 migration recipe](../../reference/recipes/java/spring/boot3/upgrad
     <plugin>
       <groupId>org.openrewrite.maven</groupId>
       <artifactId>rewrite-maven-plugin</artifactId>
-      <version>5.7.2</version>
+      <version>5.8.1</version>
       <configuration>
         <activeRecipes>
           <recipe>org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_1</recipe>


### PR DESCRIPTION
The current version used is not available on mvnrepository.com We would like to update it to a valid version.

<img width="835" alt="Screenshot 2023-10-16 at 3 25 16 PM" src="https://github.com/openrewrite/rewrite-docs/assets/8206856/c08c1128-95f9-4075-bf59-f051f6605f28">


<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Updated version of `rewrite-maven-plugin` dependency to an available version

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
