### PR TITLE
Replace hidden tabs with spaces in XML example on "Maven plugin configuration" reference page

### DIFF
--- a/reference/rewrite-maven-plugin.md
+++ b/reference/rewrite-maven-plugin.md
@@ -104,8 +104,8 @@ Note. the plugin scans the `compile`, `provided`, and `test` scopes for visitors
             <exclude>*/some/irrelevant/or/expensive/directory/**</exclude>
           </exclusions>
           <plainTextMasks>
-	    <plainTextMask>**/.txt</plainTextMask>
-	  </plainTextMasks>
+            <plainTextMask>**/.txt</plainTextMask>
+          </plainTextMasks>
         </configuration>
         <dependencies>
           <!-- This module is made up for sake of example. It isn't packaged with OpenRewrite -->

--- a/reference/rewrite-maven-plugin.md
+++ b/reference/rewrite-maven-plugin.md
@@ -146,7 +146,7 @@ Execute `mvn rewrite:dryRun` to dry-run the active recipes and print which visit
 
 `dryRun` can be used as a "gate" in a continuous integration environment by failing the build if `dryRun` detects changes to be made and `failOnDryRunResults` is set to `true`:
 
-```markup
+```xml
 <configuration>
   <failOnDryRunResults>true</failOnDryRunResults>
 </configuration>


### PR DESCRIPTION
One small followup to #284 

Apparently there are some tabs in the xml config example, which leads to it being displayed like this:

![grafik](https://github.com/openrewrite/rewrite-docs/assets/1634615/2aee5e07-ab55-4a5f-8459-b92c8c450170)
