### PR TITLE
Fix typo in docs "Migrate to JUnit 5 from JUnit 4"

### DIFF
--- a/running-recipes/popular-recipe-guides/migrate-from-junit-4-to-junit-5.md
+++ b/running-recipes/popular-recipe-guides/migrate-from-junit-4-to-junit-5.md
@@ -114,7 +114,7 @@ If your project is _not_ a Spring or Spring-Boot project take a dependency on [r
     }
     
     dependencies {
-        implementation(platform("org.openrewrite.recipe:rewrite-recipe-bom:2.13.2"))
+        rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:2.13.2"))
         rewrite("org.openrewrite.recipe:rewrite-testing-frameworks")
     
         // Other project dependencies


### PR DESCRIPTION
## What's changed?
Fixes a typo in the docs that caused the error:

```
Execution failed for task ':rewriteResolveDependencies'.
> Could not resolve all files for configuration ':detachedConfiguration1'.
   > Could not find org.openrewrite.recipe:rewrite-testing-frameworks:.
     Required by:
         project :
```

## What's your motivation?
Prevent people from suffering the same error.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
