### PR TITLE
Update bigdecimalrulesrecipes$bigdecimalvalueofrecipe.md

### DIFF
--- a/docs/recipes/tech/picnic/errorprone/refasterrules/bigdecimalrulesrecipes$bigdecimalvalueofrecipe.md
+++ b/docs/recipes/tech/picnic/errorprone/refasterrules/bigdecimalrulesrecipes$bigdecimalvalueofrecipe.md
@@ -30,6 +30,10 @@ static final class BigDecimalValueOf {
 ```
 
 
+### Tags
+
+* [RSPEC-S2111](https://sonarsource.github.io/rspec/#/rspec/S2111)
+
 ## Recipe source
 
 [GitHub](https://github.com/search?type=code&q=tech.picnic.errorprone.refasterrules.BigDecimalRulesRecipes$BigDecimalValueOfRecipe), [Issue Tracker](https://github.com/openrewrite/rewrite-third-party/issues), [Maven Central](https://central.sonatype.com/artifact/org.openrewrite.recipe/rewrite-third-party/0.10.1/jar)


### PR DESCRIPTION
add tag referencing sonar rule

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
 i have add a tag section to reference the corresponding sonar rule 

## What's your motivation?
i was first searching this recipe by sonar rule reference, i dont find it and try other keywords

## Anything in particular you'd like reviewers to focus on?
format is copied from https://docs.openrewrite.org/recipes/staticanalysis/writeoctalvaluesasdecimal#tags


