### PR TITLE
NOISSUE: Fix typo in JUnit4 to JUnit5 recipe

### DIFF
--- a/docs/running-recipes/popular-recipe-guides/migrate-from-junit-4-to-junit-5.md
+++ b/docs/running-recipes/popular-recipe-guides/migrate-from-junit-4-to-junit-5.md
@@ -58,7 +58,7 @@ If your project is a Spring or Spring-Boot project, add a dependency on [rewrite
       </dependencies>
     </plugin>
   </plugins>
-<build>
+</build>
 ```
 
 </TabItem>


### PR DESCRIPTION
## What's changed?
Small fix in the typo in the maven part of the recipe https://docs.openrewrite.org/running-recipes/popular-recipe-guides/migrate-from-junit-4-to-junit-5
The `build` closing tag does not have the correct format & is missing the `/`
<img width="921" alt="image" src="https://github.com/user-attachments/assets/cbdd35fc-16d9-44ef-8b89-b8be2a38431d">

## What's your motivation?
I am using this recipe for migrating a bunch of modules & copying the recipe from the clipboard & pasting it the `pom.xml` leads to syntax error. 