### PR TITLE
Add a default constructor for test only to pass testing in Java recipe guide.

### DIFF
--- a/docs/authoring-recipes/writing-a-java-refactoring-recipe.md
+++ b/docs/authoring-recipes/writing-a-java-refactoring-recipe.md
@@ -56,6 +56,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jetbrains.annotations.TestOnly;
 import org.jspecify.annotations.NonNull;
 import org.openrewrite.*;
 
@@ -70,6 +71,11 @@ public class SayHelloRecipe extends Recipe {
             example = "com.yourorg.FooBar")
     @NonNull
     String fullyQualifiedClassName;
+
+    @TestOnly
+    public SayHelloRecipe() {
+        fullyQualifiedClassName = "";
+    }    
 
     // All recipes must be serializable. This is verified by RewriteTest.rewriteRun() in your tests.
     @JsonCreator
@@ -99,6 +105,7 @@ package com.yourorg;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.TestOnly;
 import org.jspecify.annotations.NonNull;
 import org.openrewrite.*;
 
@@ -134,6 +141,11 @@ public class SayHelloRecipe extends Recipe {
 
     public String getFullyQualifiedClassName() {
         return fullyQualifiedClassName;
+    }
+
+    @TestOnly
+    public SayHelloRecipe() {
+        fullyQualifiedClassName = "";
     }
 
     // All recipes must be serializable. This is verified by RewriteTest.rewriteRun() in your tests.

--- a/docs/authoring-recipes/writing-a-java-refactoring-recipe.md
+++ b/docs/authoring-recipes/writing-a-java-refactoring-recipe.md
@@ -56,7 +56,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.jetbrains.annotations.TestOnly;
 import org.jspecify.annotations.NonNull;
 import org.openrewrite.*;
 
@@ -72,7 +71,6 @@ public class SayHelloRecipe extends Recipe {
     @NonNull
     String fullyQualifiedClassName;
 
-    @TestOnly
     public SayHelloRecipe() {
         fullyQualifiedClassName = "";
     }    
@@ -105,7 +103,6 @@ package com.yourorg;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.jetbrains.annotations.TestOnly;
 import org.jspecify.annotations.NonNull;
 import org.openrewrite.*;
 
@@ -143,7 +140,6 @@ public class SayHelloRecipe extends Recipe {
         return fullyQualifiedClassName;
     }
 
-    @TestOnly
     public SayHelloRecipe() {
         fullyQualifiedClassName = "";
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

```
java.lang.AssertionError: [Recipe must be able to instantiate via RecipeIntrospectionUtils] 
Expecting code not to raise a throwable but caught
  "org.openrewrite.config.RecipeIntrospectionException: Unable to call primary constructor for Recipe class ...
...
```

I found this is issue with [this commit](https://github.com/openrewrite/rewrite/commit/0eaa9a3542850578db3bf92d633b43863faf7f7f#diff-bd1b934e99c7cf3526b38925eb633f2ad10afbc2a2275d5ed0c908c393329542R168). In this commit, The `RewriteTest` will invoke `RecipeIntrospectionUtils.constructRecipe(recipe.getClass())` to do some validation. This requires our recipe should contain a default constructor.

Add a default constructor will fix it.
    
```java
    @TestOnly
    public SayHelloRecipe() {
        fullyQualifiedClassName = "";
    }    
```

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

Not sure.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
