### PR TITLE
Clickable Links to IntelliJ Settings

### DIFF
--- a/docs/reference/building-openrewrite-from-source.md
+++ b/docs/reference/building-openrewrite-from-source.md
@@ -127,11 +127,11 @@ We recommend that you use [IntelliJ IDEA](https://www.jetbrains.com/idea/) for d
 
 #### Speed up tests
 
-By default, IntelliJ IDEA uses Gradle to build and run tests with. While that ensures compatibility, it is very slow. To help speed up compilation and testing, we recommend that you change this to use `IntelliJ IDEA` instead. You can update this by going to the IntelliJ settings, searching for Gradle, and clicking on the `Build, Execution, Deployment` -> `Build Tools` -> `Gradle` setting:
+By default, IntelliJ IDEA uses Gradle to build and run tests with. While that ensures compatibility, it is very slow. To help speed up compilation and testing, we recommend that you change this to use `IntelliJ IDEA` instead. You can update this by going to the IntelliJ settings, searching for Gradle, and clicking on the [Settings | Build, Execution, Deployment | Build Tools | Gradle](jetbrains://idea/settings?name=Build%2C+Execution%2C+Deployment--Build+Tools--Gradle) setting:
 
 ![](./assets/gradle-select.png)
 
-As part of doing that, you'll also need to update the `Java Compiler` to set the `-parameters` compiler flag. If your system does not have `UTF-8` as its default character encoding (e.g., Windows), you must also add `-encoding utf8`.
+As part of doing that, you'll also need to update the Java Compiler under [Settings | Build, Execution, Deployment | Compiler | Java Compiler](jetbrains://idea/settings?name=Build%2C+Execution%2C+Deployment--Compiler--Java+Compiler) to set the `-parameters` compiler flag. If your system does not have `UTF-8` as its default character encoding (e.g., Windows), you must also add `-encoding utf8`.
 
 ![](./assets/parameters.png)
 
@@ -151,7 +151,7 @@ If you've previously run tests using Gradle and you update the project to use In
 
 _This will not apply to most people as a typical recipe module will not directly reference compiler internals._
 
-If you need to reference internals of the compiler, please add an override to the compiler parameters for the `rewrite.rewrite-java-17.main` module to have the compilation options of:
+If you need to reference internals of the compiler, please add an override to the compiler parameters under [Settings | Build, Execution, Deployment | Compiler | Java Compiler](jetbrains://idea/settings?name=Build%2C+Execution%2C+Deployment--Compiler--Java+Compiler) for the `rewrite.rewrite-java-17.main` module to have the compilation options of:
 
 ```bash
 -parameters --add-exports jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
The references to IntelliJ settings are clickable. If IntelliJ is availabel locally the correct settings window open.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Faster setup

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
