### PR TITLE
Normalize Maven multi-value settings name

### DIFF
--- a/docs/reference/rewrite-maven-plugin.md
+++ b/docs/reference/rewrite-maven-plugin.md
@@ -93,7 +93,7 @@ Note. the plugin scans the `compile`, `provided`, and `test` scopes for visitors
           <configLocation>${maven.multiModuleProjectDirectory}/rewrite.yml</configLocation>
           <failOnDryRunResults>false</failOnDryRunResults>
           <exclusions>
-            <exclude>*/some/irrelevant/or/expensive/directory/**</exclude>
+            <exclusion>*/some/irrelevant/or/expensive/directory/**</exclusion>
           </exclusions>
           <plainTextMasks>
             <plainTextMask>**/.txt</plainTextMask>


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
maven config example

## What's your motivation?
For multi-valued configuration settings like lists the Maven convention is to use a plural settings name with child elements using the same (singular) name.

## Any additional context
See also https://books.sonatype.com/mvnref-book/reference/writing-plugins-sect-mojo-params.html#writing-plugins-sect-multival-params

The previous line was probably copied from some plugin documentation with includes/excludes.