### PR TITLE
Update AssertJ recipe justification

### DIFF
--- a/docs/running-recipes/popular-recipe-guides/hamcrest-to-assertj.md
+++ b/docs/running-recipes/popular-recipe-guides/hamcrest-to-assertj.md
@@ -1,6 +1,6 @@
 # Migrate to AssertJ from Hamcrest
 
-In this tutorial, we'll use OpenRewrite to perform an automated migration from [Hamcrest](https://hamcrest.org/JavaHamcrest/) to [AssertJ](https://assertj.github.io/doc/#assertj-overview). While Hamcrest still _functions_, it hasn't been updated since 2019 and there's a growing number of [issues](https://github.com/hamcrest/JavaHamcrest/issues) and [pull requests](https://github.com/hamcrest/JavaHamcrest/pulls) open on the project. On the other hand, AssertJ has much more activity and is generally favored for testing assertions. 
+In this tutorial, we'll use OpenRewrite to perform an automated migration from [Hamcrest](https://hamcrest.org/JavaHamcrest/) to [AssertJ](https://assertj.github.io/doc/#assertj-overview). AssertJ is more actively maintained than Hamcrest and is generally favored for testing assertions. 
 
 ## Configuration
 


### PR DESCRIPTION
## What's changed?

Update the rationale for the AssertJ recipe.  Hamcrest 3.0 released in Aug 2024.

* https://github.com/hamcrest/JavaHamcrest/releases

AssertJ is more actively maintained than Hamcrest.


## What's your motivation?

Improve the accuracy of the rationale for the migration from Hamcrest to AssertJ.

## Anything in particular you'd like reviewers to focus on?

The phrasing is an attempt to accurately state the benefits of AssertJ without incorrectly claiming that Hamcrest has not released since 2019.

## Anyone you would like to review specifically?

N/A

## Have you considered any alternatives or workarounds?

If the text is not acceptable, I am happy to revise the text.

## Any additional context

Thanks for an awesome tool!  The Jenkins project is using OpenRewrite very frequently and loves the results it provides.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases N/A
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files (No, I submitted the pull request from the GitHub editor)
