### PR TITLE
Update modifying-methods-with-javatemplate.md

### DIFF
--- a/docs/authoring-recipes/modifying-methods-with-javatemplate.md
+++ b/docs/authoring-recipes/modifying-methods-with-javatemplate.md
@@ -351,7 +351,7 @@ public JavaIsoVisitor<ExecutionContext> getVisitor() {
             // ...
 
             // Add a method body
-            addMethodBodyTemplate.apply(updateCursor(methodDeclaration), methodDeclaration.getCoordinates().replaceBody());
+            methodDeclaration = addMethodBodyTemplate.apply(updateCursor(methodDeclaration), methodDeclaration.getCoordinates().replaceBody());
 
             return methodDeclaration;
         }


### PR DESCRIPTION
## What's changed?
Fixed assignment of the addMethodBodyTemplate example (pre maybeAutoFormat).

## What's your motivation?
Because the assignment is missing, the follow up text describes a situation that doesn't occur.
