### PR TITLE
Update method-patterns.md

### DIFF
--- a/docs/reference/method-patterns.md
+++ b/docs/reference/method-patterns.md
@@ -182,7 +182,7 @@ class ChangeMethodNameVisitor extends JavaIsoVisitor<ExecutionContext> {
 
         // The enclosing class of a J.MethodDeclaration must be known for a MethodMatcher to match it
         if (methodMatcher.matches(method, classDecl)) {
-            JavaType.Method type = m.getType();
+            JavaType.Method type = m.getMethodType();
 
             // Note that both the name and the type information on the declaration are updated together
             // Maintaining this consistency is important for maintaining the correct operation of other recipes
@@ -190,8 +190,8 @@ class ChangeMethodNameVisitor extends JavaIsoVisitor<ExecutionContext> {
                 type = type.withName(newMethodName);
             }
 
-            m = m.withName(m.getName().withName(newMethodName))
-                    .withType(type);
+            m = m.withName(m.getName().withSimpleName(newMethodName).withType(type))
+                                .withMethodType(type);
         }
 
         return m;
@@ -203,7 +203,7 @@ class ChangeMethodNameVisitor extends JavaIsoVisitor<ExecutionContext> {
 
         // Type information stored in the J.MethodInvocation indicates the class so no second argument is necessary
         if (methodMatcher.matches(method)) {
-            JavaType.Method type = m.getType();
+            JavaType.Method type = m.getMethodType();
 
             // Note that both the name and the type information on the invocation are updated together
             // Maintaining this consistency is important for maintaining the correct operation of other recipes
@@ -211,8 +211,8 @@ class ChangeMethodNameVisitor extends JavaIsoVisitor<ExecutionContext> {
                 type = type.withName(newMethodName);
             }
 
-            m = m.withName(m.getName().withName(newMethodName))
-                    .withType(type);
+           m = m.withName(m.getName().withSimpleName(newMethodName).withType(type))
+                                .withMethodType(type);
         }
 
         return m;


### PR DESCRIPTION
Update the `ChangeMethodNameVisitor` class.

## What's changed?
- The `getType()` returns a JavaType, changed it to `getMethodType()`. 
- With `withType()` we have to mention the `withMethodType()` as well or it will give the error of missing type or invalid type error.

## What's your motivation?
I was making a recipe to change the method name, when I refered docs I used the code provided in the `ChangeMethodNameVisitor `but it errored to `missing type or invalid type in LST`. Then I made the required changes, maybe this was the correct one used before. But now the current change works.

I reffered this https://github.com/openrewrite/rewrite/blob/main/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodName.java#L103-L110


**Before:**
```
JavaType.Method type = m.getType();
            if (type != null) {
                type = type.withName(newMethodName);
            }

            m = m.withName(m.getName().withName(newMethodName))
                    .withType(type);
        }

```
        
![image](https://github.com/user-attachments/assets/e32af8f3-7ff4-442d-b56b-72866513a800)
Or also change made in 2 cycles error.

**After:**
No error, recipe works fine.
### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
