### PR TITLE
Explain using jakarta.annotation.Generated for refaster recipes

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -4,3 +4,4 @@ https
 ssh
 ubuntu
 workarounds
+Arewrite

--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -94,3 +94,4 @@
 ^src/
 ^static/
 ignore$
+^Arewrite

--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -94,4 +94,3 @@
 ^src/
 ^static/
 ignore$
-^Arewrite

--- a/docs/authoring-recipes/refaster-recipes.md
+++ b/docs/authoring-recipes/refaster-recipes.md
@@ -167,7 +167,55 @@ dependencies {
 </TabItem>
 </Tabs>
 
+### Compiling with Java 9 or higher
 
+The annotation processor used to generate the Refaster template recipe implementation will automatically add an annotation of type `javax.annotation.Generated`. This annotation was removed from the JDK in Java 9.
+
+If your project uses Java 9 or higher, you will need to add the dependency `jakarta.annotation:jakarta.annotation-api:3.0.0` to the compilation classpath. The dependency contributes the `jakarta.annotation.Generated` annotation which is the replacement for the `javax.annotation.Generated` class. In addition, you will need to provide the flag `-Arewrite.generatedAnnotation=jakarta.annotation.Generated` to the Java compiler.
+
+<Tabs groupId="projectType">
+<TabItem value="gradle" label="Gradle">
+
+```groovy title="build.gradle"
+dependencies {
+    implementation("jakarta.annotation:jakarta.annotation-api:3.0.0")
+}
+
+tasks.named("compileJava", JavaCompile).configure {
+    options.compilerArgs.add("-Arewrite.generatedAnnotation=jakarta.annotation.Generated")
+}
+```
+
+</TabItem>
+
+<TabItem value="maven" label="Maven">
+
+```xml title="pom.xml"
+<dependencies>
+    <dependency>
+        <groupId>jakarta.annotation</groupId>
+        <artifactId>jakarta.annotation-api</artifactId>
+        <version>3.0.0</version>
+    </dependency>
+</dependencies>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <compilerArgs>
+                    <arg>-Arewrite.generatedAnnotation=jakarta.annotation.Generated</arg>
+                </compilerArgs>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+</TabItem>
+</Tabs>
 
 ### Create a Java class
 


### PR DESCRIPTION
## What's changed?

An extension to the Refaster template recipe docs that explains the handling of the `Generated` annotation.

## What's your motivation?

Refaster template recipe projects that use Java 9+ need to switch to a different annotation than `javax.annotation.Generated`. While you can find instructions on doing this in different PRs and issues, the process of equipping a project with the necessary code isn't explained explicitly. The added docs section explains it.

## Anything in particular you'd like reviewers to focus on?

No

## Anyone you would like to review specifically?

@timtebeek
