### PR TITLE
Show the Spring Boot 3.5 migration on main page

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -17,7 +17,7 @@ It consists of an auto-refactoring engine that runs prepackaged, open-source ref
 
  ## How does OpenRewrite work?
 
-<ReactPlayer url='https://www.youtube.com/watch?v=nz29-DWeV44' controls="true" />
+<ReactPlayer className="reactPlayer" url='https://www.youtube.com/watch?v=LgvqAzTxkEU' controls="true" />
 
 <br/>
 


### PR DESCRIPTION
As opposed to the outdated 3.2 migration.