### PR TITLE
Add "Semantics class shortcut" section to JavaTemplate

### DIFF
--- a/docs/concepts-and-explanations/javatemplate.md
+++ b/docs/concepts-and-explanations/javatemplate.md
@@ -22,7 +22,8 @@ public class ChangeMethodInvocation extends JavaIsoVisitor<ExecutionContext> {
                 JavaParser.fromJavaVersion()                                   // Parser
                     .classpath("example-utils"))                               // Classpath lookup
             .staticImports("org.example.StringUtils.withString")               // Additional import
-            .doBeforeParseTemplate((String template) -> {})                    // Optional side-effect
+            .doAfterVariableSubstitution(System.out::println)                  // Optional side-effect
+            .doBeforeParseTemplate(System.out::println)                        // Optional side-effect
             .build();
 }
 ```


### PR DESCRIPTION
## What's changed?
A new "Semantics class shortcut" section has been added to the JavaTemplate documentation.

## What's your motivation?
The Semantics class has already been used in some of our recipes (like [IsNotEmptyToJdk](https://github.com/openrewrite/rewrite-apache/blob/d83e6f47b240ae9959684c5927861db91e19157c/src/main/java/org/openrewrite/apache/commons/lang/IsNotEmptyToJdk.java#L74-L77)). No documentation was available about this worked exactly.