### PR TITLE
Document single-recipe option passing for Maven plugin without full build

### DIFF
--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -211,7 +211,7 @@ This is a challenging problem for a couple of reasons:
 
 We generally recommend using a `rewrite.yml` file to configure recipes. This avoids ambiguity about which recipe instances are being configured and ensures the setup is portable across the different tools that run OpenRewrite recipes.
 
-If you're using the [rewrite-maven-plugin](https://github.com/openrewrite/rewrite-maven-plugin), we [added](https://github.com/openrewrite/rewrite-maven-plugin/pull/816) basic support for passing arguments to recipes, though it's currently limited to single-recipe runs.
+If you're using the [rewrite-maven-plugin](https://github.com/openrewrite/rewrite-maven-plugin), we [added basic support for passing arguments to recipes](https://github.com/openrewrite/rewrite-maven-plugin/pull/816), though it's currently limited to single-recipe runs.
 Using the below command you remove an argument plugin without modifying a `rewrite.yml` or `pom.xml` file:
 
 ```shell

--- a/docs/running-recipes/running-rewrite-on-a-maven-project-without-modifying-the-build.md
+++ b/docs/running-recipes/running-rewrite-on-a-maven-project-without-modifying-the-build.md
@@ -61,7 +61,7 @@ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
 
 While the preferred way to configure recipes is through a `rewrite.yml` file, it is possible to pass configuration parameters directly from the command line. However, this only works when running a _single_ recipe.
 
-For example, to run the [AddCommentToMethod](../recipes/java/addcommenttomethod.md) recipe without modifying your pom.xml, you can use the following command:
+For example, to run the [AddCommentToMethod](../recipes/java/addcommenttomethod.md) recipe without modifying your `pom.xml`, you can use the following command:
 
 ```shell
 mvn org.openrewrite.maven:rewrite-maven-plugin:run \


### PR DESCRIPTION
## What's changed?
Since https://github.com/openrewrite/rewrite-maven-plugin/pull/816 it is possible to apply options  when running a single recipe with maven. The docs did state this in the FAQ, but not on the "Running Rewrite on a Maven project without modifying the build" page. 

## What's your motivation?
Updating old docs with current features.