### PR TITLE
Update snapshot-instructions.md

### DIFF
--- a/docs/reference/snapshot-instructions.md
+++ b/docs/reference/snapshot-instructions.md
@@ -96,5 +96,5 @@ For instance, if the latest release of the `rewrite-maven-plugin` is `6.21.1`, t
 You will need to have [Maven](https://maven.apache.org/download.cgi) installed on your machine before you can run the following command.
 
 ```shell title="shell"
-mvn -U org.openrewrite.maven:rewrite-maven-plugin:6.22.0-SNAPSHOT:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:3.20.0-SNAPSHOT -Drewrite.activeRecipes=org.openrewrite.java.migrate.guava.NoGuava -Drewrite.exportDatatables=true ```
-
+mvn -U org.openrewrite.maven:rewrite-maven-plugin:6.22.0-SNAPSHOT:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:3.20.0-SNAPSHOT -Drewrite.activeRecipes=org.openrewrite.java.migrate.guava.NoGuava -Drewrite.exportDatatables=true
+```


### PR DESCRIPTION
## What's changed?
Add a section for the Maven Command Line

## What's your motivation?
- In the issue [#881](https://github.com/openrewrite/rewrite-migrate-java/issues/881#issuecomment-3425779590), Tim pointed me to this documentation. However, it didn’t include instructions for the Maven command line, which is what I use to run the recipe. After some research, I figured out how to adapt the command line, and I’m sure I’m not the only one with this question.

## Anyone you would like to review specifically?
@timtebeek 