### PR TITLE
Add type attribution reference

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -119,6 +119,7 @@ const sidebars: SidebarsConfig = {
         'reference/gradle-plugin-configuration',
         'reference/supported-languages',
         'reference/snapshot-instructions',
+        'reference/type-attribution',
         'reference/jsonpath-and-jsonpathmatcher-reference',
         'reference/yaml-format-reference',
         'reference/method-patterns',


### PR DESCRIPTION
Perhaps we want to also add a shorter "type attribution" entry under concepts & explanations which could stick to describing the nature and importance of type attribution in a more general way.