### PR TITLE
Add training promotion banners to authoring-recipes docs

### DIFF
--- a/docs/authoring-recipes/data-tables.md
+++ b/docs/authoring-recipes/data-tables.md
@@ -7,6 +7,10 @@ import TabItem from '@theme/TabItem';
 
 # Creating recipes with data tables
 
+:::info[Free Workshop]
+Take your recipes further. [Join our free advanced OpenRewrite workshop in June →](https://www.moderne.ai/training/advanced-openrewrite-training-moderne-june-session)
+:::
+
 Traditionally, recipes either tried to fix an issue by updating the code directly or they helped you find pieces of code based on a query. However, what if you wanted to extract some specific attributes or inferences from the code? For example, what if you wanted to know details about the vulnerabilities that exist in one of your repositories?
 
 This is where data tables come in. In addition to modifying the code directly, recipes can generate tabular data that people can use for analysis purposes. Taking the security vulnerability scenario as an example, a recipe could fix certain vulnerabilities and produce a table containing vital information about what vulnerabilities exist in your repository. This information could include a summary of the CVE, the severity of the issue, and whether or not a version update could address the vulnerability.

--- a/docs/authoring-recipes/modifying-methods-with-javatemplate.md
+++ b/docs/authoring-recipes/modifying-methods-with-javatemplate.md
@@ -4,6 +4,10 @@ description: A deeper look into how you can use JavaTemplates to refactor/modify
 
 # Modifying methods with JavaTemplates
 
+:::info[Free Training]
+New to writing recipes? [Join our free Authoring OpenRewrite Recipes: Fundamentals course →](https://www.moderne.ai/training/authoring-openrewrite-recipes-fundamentals)
+:::
+
 Previously, we wrote a Java recipe that [added a hello() method to a class if it didn't already have one](./writing-a-java-refactoring-recipe.md). In that guide, we used a `JavaTemplate` to create a basic method. However, a `JavaTemplate` can be used for much more complicated changes, such as refactoring existing methods. Let's explore that.
 
 In this guide, you will build a recipe that [finds a specific abstract method](#limit-the-visitors-scope) and:

--- a/docs/authoring-recipes/multiple-visitors.md
+++ b/docs/authoring-recipes/multiple-visitors.md
@@ -5,6 +5,10 @@ description: How to create recipes that contain and use multiple visitors.
 
 # Creating multiple visitors in one recipe
 
+:::info[Free Workshop]
+Take your recipes further. [Join our free advanced OpenRewrite workshop in June →](https://www.moderne.ai/training/advanced-openrewrite-training-moderne-june-session)
+:::
+
 As you begin to write increasingly complex recipes, you will find that it is often necessary to have more than one visitor. This is because significant changes often require you to visit many types of [Lossless Semantic Trees](../concepts-and-explanations/lossless-semantic-trees.md) (LSTs) to figure out whether or not a change should be made.
 
 For instance, let's say that you wanted to write a recipe that adds the `final` modifier to any local variables that aren't reassigned. To do that, you would first need to make a visitor that visits all of the `VariableDeclarations` and runs some checks on them (such as determining if they already have the `final` modifier). Once you found all potential variables, you would then need to visit all of the places they could be used to see if they are reassigned. If they were reassigned, you would need to keep track of that across visits, too. Both of those issues can be solved by adding a second visitor to your recipe.

--- a/docs/authoring-recipes/recipe-conventions-and-best-practices.md
+++ b/docs/authoring-recipes/recipe-conventions-and-best-practices.md
@@ -4,6 +4,10 @@ description: A list of important conventions and best practices to keep in mind 
 
 # Recipe conventions and best practices
 
+:::info[Free Workshop]
+Take your recipes further. [Join our free advanced OpenRewrite workshop in June →](https://www.moderne.ai/training/advanced-openrewrite-training-moderne-june-session)
+:::
+
 To help you create reliable and scalable recipes, this document will describe an assortment of conventions and best practices to keep in mind when making new recipes.
 
 ## Prerequisites

--- a/docs/authoring-recipes/recipe-development-environment.md
+++ b/docs/authoring-recipes/recipe-development-environment.md
@@ -8,6 +8,10 @@ import TabItem from '@theme/TabItem';
 
 # Recipe development environment
 
+:::info[Free Training]
+New to writing recipes? [Join our free Authoring OpenRewrite Recipes: Fundamentals course →](https://www.moderne.ai/training/authoring-openrewrite-recipes-fundamentals)
+:::
+
 This getting started guide covers setting up your development environment for creating your own OpenRewrite recipes.
 
 :::info

--- a/docs/authoring-recipes/recipe-testing.md
+++ b/docs/authoring-recipes/recipe-testing.md
@@ -10,6 +10,10 @@ import TabItem from '@theme/TabItem';
 
 # Recipe testing
 
+:::info[Free Training]
+New to writing recipes? [Join our free Authoring OpenRewrite Recipes: Fundamentals course →](https://www.moderne.ai/training/authoring-openrewrite-recipes-fundamentals)
+:::
+
 When developing new recipes, it's very important to test them to ensure that they not only make the expected changes but that they also **don't** make unnecessary changes.
 
 To help you create tests that meet those standards, this guide will walk you through everything you need to know – from what dependencies to add, to example recipes and their tests, to advanced testing concepts. By the end, you should be writing great tests for your own recipes.

--- a/docs/authoring-recipes/types-of-recipes.md
+++ b/docs/authoring-recipes/types-of-recipes.md
@@ -4,6 +4,10 @@ description: Describes what the three types of recipes are, and what their advan
 
 # Types of recipes
 
+:::info[Free Training]
+New to writing recipes? [Join our free Authoring OpenRewrite Recipes: Fundamentals course →](https://www.moderne.ai/training/authoring-openrewrite-recipes-fundamentals)
+:::
+
 Before you jump into coding recipes, it's important to figure out what type of recipe you're going to make.
 
 OpenRewrite offers support for three different types of recipes: declarative, refaster, and imperative. Each of these has its own advantages and disadvantages depending on the type of recipe you want to build. 

--- a/docs/authoring-recipes/writing-a-java-refactoring-recipe.md
+++ b/docs/authoring-recipes/writing-a-java-refactoring-recipe.md
@@ -9,6 +9,10 @@ import TabItem from '@theme/TabItem';
 
 # Writing a Java refactoring recipe
 
+:::info[Free Training]
+New to writing recipes? [Join our free Authoring OpenRewrite Recipes: Fundamentals course →](https://www.moderne.ai/training/authoring-openrewrite-recipes-fundamentals)
+:::
+
 To help you get started with writing recipes, this guide will walk you through all the steps needed to create a basic refactoring recipe. This `SayHelloRecipe` will add a `hello()` method to a user specified class if that class does not already have one.
 
 For example, it would take a class like this:

--- a/docs/authoring-recipes/writing-recipes-over-multiple-source-file-types.md
+++ b/docs/authoring-recipes/writing-recipes-over-multiple-source-file-types.md
@@ -5,6 +5,10 @@ description: How to create recipes that examine many different types of files.
 
 # Writing recipes over multiple source file types
 
+:::info[Free Workshop]
+Take your recipes further. [Join our free advanced OpenRewrite workshop in June →](https://www.moderne.ai/training/advanced-openrewrite-training-moderne-june-session)
+:::
+
 When creating new recipes, you may find it desirable to examine multiple source files, potentially of different types, to make key decisions in your visitor. For example, you may want to look for a particular condition to be present in a Maven POM file and, if that condition is met, alter an application property in a YAML file.
 
 In situations like that, you should create a [ScanningRecipe](https://github.com/openrewrite/rewrite/blob/v8.1.2/rewrite-core/src/main/java/org/openrewrite/ScanningRecipe.java). In there, you'll then make an `accumulator` which visitors can read from and write to as needed. For a more thorough explanation of scanning recipes, please see [our recipe concepts doc](../concepts-and-explanations/recipes.md#scanning-recipes)


### PR DESCRIPTION
## Summary
- Add Fundamentals course promo to 5 authoring-recipes pages: recipe-development-environment, types-of-recipes, writing-a-java-refactoring-recipe, recipe-testing, and modifying-methods-with-javatemplate
- Add Advanced workshop (June session) promo to 4 pages: recipe-conventions-and-best-practices, data-tables, multiple-visitors, and writing-recipes-over-multiple-source-file-types
- Follows the same banner pattern as the earlier #470 training promos

## Test plan
- [x] Verified banners render correctly on a local Docusaurus build (`yarn start`)
- [ ] Confirm links resolve to the correct Moderne training registration pages