### PR TITLE
Typography refresh: Inter throughout, smaller H1

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -202,10 +202,10 @@ html[data-theme=dark] [class^=docMainContainer_] .breadcrumbs__link:hover {
 }
 
 [class^=docMainContainer_] h1 {
-  --ifm-heading-font-weight: 300;
-  --ifm-heading-font-family: "Beausite", sans-serif;
-  --ifm-h1-font-size: 3.75rem;
-  --ifm-leading: 1;
+  --ifm-heading-font-weight: 600;
+  --ifm-heading-font-family: "Inter", sans-serif;
+  --ifm-h1-font-size: 2.25rem;
+  --ifm-leading: 1.2;
 
   margin-bottom: 1.25rem;
 }
@@ -241,8 +241,8 @@ html[data-theme='dark'] [class^=docMainContainer_] .card {
 }
 
 .markdown {
-  --ifm-heading-font-family: "Beausite", sans-serif;
-  --ifm-heading-font-weight: 300;
+  --ifm-heading-font-family: "Inter", sans-serif;
+  --ifm-heading-font-weight: 600;
   --ifm-link-decoration: underline;
 }
 


### PR DESCRIPTION
- Part of #492. Targets the [visual refresh sandbox branch](https://github.com/openrewrite/rewrite-docs/pull/493).

## Changes

- H1: Beausite Slick 300 / 3.75rem → Inter 600 / 2.25rem, line-height 1 → 1.2
- Markdown headings: Beausite 300 → Inter 600

Live preview at `/sandbox`.

## Test plan
- [ ] H1s render in Inter Semibold on docs pages
- [ ] No Beausite font requests in network tab on docs pages
- [ ] Markdown subheadings (h2/h3) inherit Inter