### PR TITLE
Set inline code / code-block font size to 13px

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -24,7 +24,7 @@
   --ifm-color-primary-lighter: #6787e7;
   --ifm-color-primary-lightest: #8ca4ed;
   --ifm-color-border: #D9D9D9;
-  --ifm-code-font-size: 95%;
+  --ifm-code-font-size: 81.25%;
   --ifm-color-base: rgba(4, 24, 52);
   --ifm-color-content: var(--ifm-color-base);
   --ifm-color-announcement-bar-bg: var(--ifm-color-mint);


### PR DESCRIPTION
- Part of #492. Targets the [visual refresh sandbox branch](https://github.com/openrewrite/rewrite-docs/pull/493).

## Changes

`--ifm-code-font-size`: 95% → 81.25%, so inline `code` and code blocks render at 13px instead of 15.2px. Better balance against the 16px Inter body.

## Test plan
- [ ] Inline `code` renders at 13px against 16px body text
- [ ] Code blocks render at 13px
- [ ] Token spans (e.g. Prism syntax highlighting) match