### PR TITLE
Visual polish: neo card tokens, rounded media, sidebar active leaf

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -436,3 +436,69 @@ html[data-theme='dark'] {
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 calc(var(--ifm-pre-padding) - 3px) 0 var(--ifm-pre-padding);
 }
+
+/* ============================================================
+ * Visual polish — neo card design tokens, rounded media,
+ * sidebar active-leaf weight bump.
+ * Additive overrides; safe to land regardless of which other
+ * visual-refresh PRs merge first.
+ * ============================================================ */
+
+:root {
+  --neo-border-card: rgba(4, 24, 52, 0.12);
+  --neo-grey-300: rgba(4, 24, 52, 0.25);
+  --neo-shadow-card: 0 1px 2px rgba(4, 24, 52, 0.06), 0 4px 12px rgba(4, 24, 52, 0.05);
+  --neo-card-hover-bg: #FFFFFF;
+}
+
+html[data-theme='dark'] {
+  --neo-border-card: rgba(255, 255, 255, 0.1);
+  --neo-grey-300: rgba(255, 255, 255, 0.25);
+  --neo-shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3), 0 4px 12px rgba(0, 0, 0, 0.2);
+  --neo-card-hover-bg: rgba(255, 255, 255, 0.04);
+}
+
+/* DocCard — transparent default, white on hover with shadow lift */
+[class^=cardContainer_] {
+  background-color: transparent !important;
+  border-color: var(--neo-border-card) !important;
+  transition: background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease !important;
+}
+
+[class^=cardContainer_]:hover {
+  background-color: var(--neo-card-hover-bg) !important;
+  border-color: var(--neo-grey-300) !important;
+  box-shadow: var(--neo-shadow-card) !important;
+}
+
+/* Markdown link-list cards — same treatment */
+.markdown ul:has(> li > a:only-child) > li > a {
+  background-color: transparent !important;
+  border-color: var(--neo-border-card) !important;
+  transition: background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease !important;
+}
+
+.markdown ul:has(> li > a:only-child) > li > a:hover {
+  background-color: var(--neo-card-hover-bg) !important;
+  border-color: var(--neo-grey-300) !important;
+  box-shadow: var(--neo-shadow-card) !important;
+}
+
+/* Rounded corners on inline media */
+.markdown img,
+figure img {
+  border-radius: 12px;
+}
+
+.markdown iframe[src*="youtube"],
+.markdown iframe[src*="youtu.be"],
+.markdown iframe[src*="vimeo"],
+.markdown iframe {
+  border-radius: 12px;
+}
+
+/* Sidebar active-leaf — bump to 700 Inter for stronger emphasis */
+.theme-doc-sidebar-menu .menu__link:not(.menu__link--sublist).menu__link--active {
+  font-weight: 700 !important;
+  font-family: "Inter", sans-serif !important;
+}


### PR DESCRIPTION
- Part of #492. Targets the [visual refresh sandbox branch](https://github.com/openrewrite/rewrite-docs/pull/493).

## Changes

### Design tokens
Added `--neo-border-card`, `--neo-grey-300`, `--neo-shadow-card`, `--neo-card-hover-bg` to `:root` and the dark-mode block.

### Card hover treatment
Both `DocCard` (generated index pages) and markdown link-list cards (recipe READMEs):

- **Default:** transparent fill (page lavender shows through), 1px `--neo-border-card` outline only
- **Hover:** card fills white (`--neo-card-hover-bg`), border deepens to `--neo-grey-300`, gains `--neo-shadow-card` lift
- **Transition:** 120ms ease on bg + border + shadow

### Other polish
- Round corners (12px) on `.markdown img`, `figure img`, and any `.markdown iframe` (YouTube/Vimeo embeds inline in markdown beyond `.reactPlayer`)
- Sidebar active leaf bumped to `font-weight: 700` + Inter

## Notes

Self-contained: written as additive `!important` overrides + attribute selectors so it lands cleanly regardless of merge order with the other refresh PRs.

## Test plan
- [ ] DocCards default transparent against page lavender, hover white with shadow lift
- [ ] Recipe README link-list cards behave the same way
- [ ] Inline images and embeds in docs have rounded corners
- [ ] Active sidebar item appears bolder than category labels
- [ ] Dark mode tokens work (translucent white tints)