### PR TITLE
Restore subtle border on code blocks in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -100,6 +100,10 @@ html[data-theme='dark'] {
   --neo-frame-bg: rgba(255, 255, 255, 0.04);
 }
 
+html[data-theme='dark'] .theme-code-block {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
 .navbar__logo img {
   height: 33px;
 }


### PR DESCRIPTION
- Part of #492. Targets the visual refresh sandbox branch.

## Context

- In #502 I dropped the legacy `html[data-theme='dark'] .theme-code-block { border: 1.5px solid var(--ifm-color-border) }` because it was producing an unwanted wrapper-gap (the outer `.theme-code-block` div with padding around the inner `<pre>` looked like a double-border on code blocks).

Without it though, dark-mode code blocks blend into the page and the edge is hard to read.

## Change

Add a 1px `rgba(255, 255, 255, 0.12)` border back, scoped to dark mode only. Lighter than the original 1.5px so it reads as a subtle boundary, not a frame.

## Test plan
- [ ] Dark mode: code block has a thin visible border
- [ ] Light mode: unchanged
- [ ] No reappearance of the double-border / wrapper-gap issue