### PR TITLE
Remove Fundamentals course training promos

### DIFF
--- a/docs/authoring-recipes/modifying-methods-with-javatemplate.md
+++ b/docs/authoring-recipes/modifying-methods-with-javatemplate.md
@@ -4,10 +4,6 @@ description: A deeper look into how you can use JavaTemplates to refactor/modify
 
 # Modifying methods with JavaTemplates
 
-:::info[Free Training]
-New to writing recipes? [Join our free Authoring OpenRewrite Recipes: Fundamentals course →](https://www.moderne.ai/training/authoring-openrewrite-recipes-fundamentals)
-:::
-
 Previously, we wrote a Java recipe that [added a hello() method to a class if it didn't already have one](./writing-a-java-refactoring-recipe.md). In that guide, we used a `JavaTemplate` to create a basic method. However, a `JavaTemplate` can be used for much more complicated changes, such as refactoring existing methods. Let's explore that.
 
 In this guide, you will build a recipe that [finds a specific abstract method](#limit-the-visitors-scope) and:

--- a/docs/authoring-recipes/recipe-development-environment.md
+++ b/docs/authoring-recipes/recipe-development-environment.md
@@ -8,10 +8,6 @@ import TabItem from '@theme/TabItem';
 
 # Recipe development environment
 
-:::info[Free Training]
-New to writing recipes? [Join our free Authoring OpenRewrite Recipes: Fundamentals course →](https://www.moderne.ai/training/authoring-openrewrite-recipes-fundamentals)
-:::
-
 This getting started guide covers setting up your development environment for creating your own OpenRewrite recipes.
 
 :::info

--- a/docs/authoring-recipes/recipe-testing.md
+++ b/docs/authoring-recipes/recipe-testing.md
@@ -10,10 +10,6 @@ import TabItem from '@theme/TabItem';
 
 # Recipe testing
 
-:::info[Free Training]
-New to writing recipes? [Join our free Authoring OpenRewrite Recipes: Fundamentals course →](https://www.moderne.ai/training/authoring-openrewrite-recipes-fundamentals)
-:::
-
 When developing new recipes, it's very important to test them to ensure that they not only make the expected changes but that they also **don't** make unnecessary changes.
 
 To help you create tests that meet those standards, this guide will walk you through everything you need to know – from what dependencies to add, to example recipes and their tests, to advanced testing concepts. By the end, you should be writing great tests for your own recipes.

--- a/docs/authoring-recipes/types-of-recipes.md
+++ b/docs/authoring-recipes/types-of-recipes.md
@@ -4,10 +4,6 @@ description: Describes what the three types of recipes are, and what their advan
 
 # Types of recipes
 
-:::info[Free Training]
-New to writing recipes? [Join our free Authoring OpenRewrite Recipes: Fundamentals course →](https://www.moderne.ai/training/authoring-openrewrite-recipes-fundamentals)
-:::
-
 Before you jump into coding recipes, it's important to figure out what type of recipe you're going to make.
 
 OpenRewrite offers support for three different types of recipes: declarative, refaster, and imperative. Each of these has its own advantages and disadvantages depending on the type of recipe you want to build. 

--- a/docs/authoring-recipes/writing-a-java-refactoring-recipe.md
+++ b/docs/authoring-recipes/writing-a-java-refactoring-recipe.md
@@ -9,10 +9,6 @@ import TabItem from '@theme/TabItem';
 
 # Writing a Java refactoring recipe
 
-:::info[Free Training]
-New to writing recipes? [Join our free Authoring OpenRewrite Recipes: Fundamentals course →](https://www.moderne.ai/training/authoring-openrewrite-recipes-fundamentals)
-:::
-
 To help you get started with writing recipes, this guide will walk you through all the steps needed to create a basic refactoring recipe. This `SayHelloRecipe` will add a `hello()` method to a user specified class if that class does not already have one.
 
 For example, it would take a class like this:


### PR DESCRIPTION
## What

Removes the 5 `:::info[Free Training]` banners promoting the **Authoring OpenRewrite Recipes: Fundamentals course**, which has now ended.

Files updated:
- `docs/authoring-recipes/modifying-methods-with-javatemplate.md`
- `docs/authoring-recipes/recipe-development-environment.md`
- `docs/authoring-recipes/recipe-testing.md`
- `docs/authoring-recipes/types-of-recipes.md`
- `docs/authoring-recipes/writing-a-java-refactoring-recipe.md`

## What's kept

The 4 `:::info[Free Workshop]` banners for the **advanced OpenRewrite workshop (June session)** — added in the same commit (df5672fd00) — are intentionally left in place since that session is still upcoming.

The long-standing evergreen "recipe authoring workshop" links (to docs.moderne.io) were not part of the promo commit and are untouched.

## Verification

`5 files changed, 20 deletions(-)` — pure removal (4 lines each), restoring the files to their exact pre-promo state.