### PR TITLE
Remove advanced OpenRewrite workshop (June) training promos

### DIFF
--- a/docs/authoring-recipes/data-tables.md
+++ b/docs/authoring-recipes/data-tables.md
@@ -7,10 +7,6 @@ import TabItem from '@theme/TabItem';
 
 # Creating recipes with data tables
 
-:::info[Free Workshop]
-Take your recipes further. [Join our free advanced OpenRewrite workshop in June →](https://www.moderne.ai/training/advanced-openrewrite-training-moderne-june-session)
-:::
-
 Traditionally, recipes either tried to fix an issue by updating the code directly or they helped you find pieces of code based on a query. However, what if you wanted to extract some specific attributes or inferences from the code? For example, what if you wanted to know details about the vulnerabilities that exist in one of your repositories?
 
 This is where data tables come in. In addition to modifying the code directly, recipes can generate tabular data that people can use for analysis purposes. Taking the security vulnerability scenario as an example, a recipe could fix certain vulnerabilities and produce a table containing vital information about what vulnerabilities exist in your repository. This information could include a summary of the CVE, the severity of the issue, and whether or not a version update could address the vulnerability.

--- a/docs/authoring-recipes/multiple-visitors.md
+++ b/docs/authoring-recipes/multiple-visitors.md
@@ -5,10 +5,6 @@ description: How to create recipes that contain and use multiple visitors.
 
 # Creating multiple visitors in one recipe
 
-:::info[Free Workshop]
-Take your recipes further. [Join our free advanced OpenRewrite workshop in June →](https://www.moderne.ai/training/advanced-openrewrite-training-moderne-june-session)
-:::
-
 As you begin to write increasingly complex recipes, you will find that it is often necessary to have more than one visitor. This is because significant changes often require you to visit many types of [Lossless Semantic Trees](../concepts-and-explanations/lossless-semantic-trees.md) (LSTs) to figure out whether or not a change should be made.
 
 For instance, let's say that you wanted to write a recipe that adds the `final` modifier to any local variables that aren't reassigned. To do that, you would first need to make a visitor that visits all of the `VariableDeclarations` and runs some checks on them (such as determining if they already have the `final` modifier). Once you found all potential variables, you would then need to visit all of the places they could be used to see if they are reassigned. If they were reassigned, you would need to keep track of that across visits, too. Both of those issues can be solved by adding a second visitor to your recipe.

--- a/docs/authoring-recipes/recipe-conventions-and-best-practices.md
+++ b/docs/authoring-recipes/recipe-conventions-and-best-practices.md
@@ -4,10 +4,6 @@ description: A list of important conventions and best practices to keep in mind 
 
 # Recipe conventions and best practices
 
-:::info[Free Workshop]
-Take your recipes further. [Join our free advanced OpenRewrite workshop in June →](https://www.moderne.ai/training/advanced-openrewrite-training-moderne-june-session)
-:::
-
 To help you create reliable and scalable recipes, this document will describe an assortment of conventions and best practices to keep in mind when making new recipes.
 
 ## Prerequisites

--- a/docs/authoring-recipes/writing-recipes-over-multiple-source-file-types.md
+++ b/docs/authoring-recipes/writing-recipes-over-multiple-source-file-types.md
@@ -5,10 +5,6 @@ description: How to create recipes that examine many different types of files.
 
 # Writing recipes over multiple source file types
 
-:::info[Free Workshop]
-Take your recipes further. [Join our free advanced OpenRewrite workshop in June →](https://www.moderne.ai/training/advanced-openrewrite-training-moderne-june-session)
-:::
-
 When creating new recipes, you may find it desirable to examine multiple source files, potentially of different types, to make key decisions in your visitor. For example, you may want to look for a particular condition to be present in a Maven POM file and, if that condition is met, alter an application property in a YAML file.
 
 In situations like that, you should create a [ScanningRecipe](https://github.com/openrewrite/rewrite/blob/v8.1.2/rewrite-core/src/main/java/org/openrewrite/ScanningRecipe.java). In there, you'll then make an `accumulator` which visitors can read from and write to as needed. For a more thorough explanation of scanning recipes, please see [our recipe concepts doc](../concepts-and-explanations/recipes.md#scanning-recipes)


### PR DESCRIPTION
The June advanced OpenRewrite workshop is over, so this removes its promotional `:::info[Free Workshop]` banners.

- These banners were added in #487 (April 16) alongside the Fundamentals/intro promos. When the April promos were cleaned up in `8033cf64d0`, only the intro banners (on concepts and running-recipes pages) were removed — these four advanced-workshop banners in `authoring-recipes/` were left behind.

## Removed from
- `docs/authoring-recipes/data-tables.md`
- `docs/authoring-recipes/multiple-visitors.md`
- `docs/authoring-recipes/recipe-conventions-and-best-practices.md`
- `docs/authoring-recipes/writing-recipes-over-multiple-source-file-types.md`

A grep confirms no advanced-workshop promos remain. The evergreen "OpenRewrite advanced program analysis" section in `docs/training.md` is left intact (it's reference content, not a dated promo).