### PR TITLE
Update community-recipes.md

### DIFF
--- a/docs/reference/community-recipes.md
+++ b/docs/reference/community-recipes.md
@@ -77,3 +77,5 @@ If you want to see your project on this list - please feel free to click on the 
   * Migrates a Camunda 7 instance to Operaton.
 * [Rewrite Format SQL](https://github.com/mhagnumdw/rewrite-format-sql)
   * OpenRewrite recipes for formatting SQL code in text blocks in annotations.
+* [JDO to JPA migration](https://github.com/ecpnv-devops/jdo2jpa)
+  * Migrates a project using JDO ORM implementation to a JPA implementation. Supports DataNucleus, EclipseLink and Apache Causeway, but should also work for Hibernate.


### PR DESCRIPTION
Added the JDO to JPA migration recipes link

## What's changed?
Added the JDO to JPA migration recipes link to the public repo.

## What's your motivation?
This will help the community with migrating JDO projects to JPA and the public repo provides many new generic recipes.
