### PR TITLE
Correct staging CLI version in recent changelogs

### DIFF
--- a/docs/changelog/8-60-0-Release.md
+++ b/docs/changelog/8-60-0-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.43.6`
-* Staging CLI version: `v3.44.4`
+* Staging CLI version `v3.44.4`
 
 ## New Artifacts
 * rewrite-program-analysis

--- a/docs/changelog/8-61-1-Release.md
+++ b/docs/changelog/8-61-1-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.43.6`
-* Staging CLI version: `v3.45.3`
+* Staging CLI version `v3.45.3`
 
 ## New Artifacts
 * rewrite-joda

--- a/docs/changelog/8-62-0-Release.md
+++ b/docs/changelog/8-62-0-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.43.6`
-* Staging CLI version: `v3.47.0`
+* Staging CLI version `v3.47.0`
 
 ## New Artifacts
 * rewrite-elastic

--- a/docs/changelog/8-62-4-Release.md
+++ b/docs/changelog/8-62-4-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.47.0`
-* Staging CLI version: `v3.48.5`
+* Staging CLI version `v3.48.5`
 
 ## New Recipes
 

--- a/docs/changelog/8-63-0-Release.md
+++ b/docs/changelog/8-63-0-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.48.8`
-* Staging CLI version: `v3.49.0`
+* Staging CLI version `v3.49.0`
 
 ## New Artifacts
 

--- a/docs/changelog/8-64-0-Release.md
+++ b/docs/changelog/8-64-0-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.49.0`
-* Staging CLI version: `v3.50.0`
+* Staging CLI version `v3.50.0`
 
 ## New Artifacts
 

--- a/docs/changelog/8-66-1-Release.md
+++ b/docs/changelog/8-66-1-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.50.1`
-* Staging CLI version: `v3.50.1`
+* Staging CLI version `v3.50.1`
 
 ## New Recipes
 

--- a/docs/changelog/8-67-0-Release.md
+++ b/docs/changelog/8-67-0-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.51.2`
-* Staging CLI version: `v3.51.3`
+* Staging CLI version `v3.51.3`
 
 ## New Artifacts
 

--- a/docs/changelog/8-68-1-Release.md
+++ b/docs/changelog/8-68-1-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.51.2`
-* Staging CLI version: `v3.51.4`
+* Staging CLI version `v3.51.4`
 
 ## New Artifacts
 

--- a/docs/changelog/8-69-0-Release.md
+++ b/docs/changelog/8-69-0-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.53.2`
-* Staging CLI version: `v3.54.1`
+* Staging CLI version `v3.54.1`
 
 ## New Artifacts
 

--- a/docs/changelog/8-71-0-Release.md
+++ b/docs/changelog/8-71-0-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.53.2`
-* Staging CLI version: `v3.54.5`
+* Staging CLI version `v3.54.5`
 
 ## Removed Artifacts
 

--- a/docs/changelog/8-72-0-Release.md
+++ b/docs/changelog/8-72-0-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.53.2`
-* Staging CLI version: `v3.55.3`
+* Staging CLI version `v3.55.3`
 
 ## New Artifacts
 

--- a/docs/changelog/8-73-0-Release.md
+++ b/docs/changelog/8-73-0-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.53.2`
-* Staging CLI version: `v3.57.1`
+* Staging CLI version `v3.57.1`
 
 ## New Artifacts
 

--- a/docs/changelog/8-74-1-Release.md
+++ b/docs/changelog/8-74-1-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.57.6`
-* Staging CLI version: `v3.57.11`
+* Staging CLI version `v3.57.11`
 
 ## New Artifacts
 

--- a/docs/changelog/8-75-2-Release.md
+++ b/docs/changelog/8-75-2-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.57.12`
-* Staging CLI version: `v3.57.14`
+* Staging CLI version `v3.57.14`
 
 ## New Recipes
 

--- a/docs/changelog/8-79-1-Release.md
+++ b/docs/changelog/8-79-1-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.57.16`
-* Staging CLI version: `v3.57.16`
+* Staging CLI version: `v4.1.1`
 
 ## Removed Artifacts
 

--- a/docs/changelog/8-79-1-Release.md
+++ b/docs/changelog/8-79-1-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.57.16`
-* Staging CLI version: `v4.1.1`
+* Staging CLI version `v4.1.1`
 
 ## Removed Artifacts
 

--- a/docs/changelog/8-81-0-Release.md
+++ b/docs/changelog/8-81-0-Release.md
@@ -12,8 +12,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 
 ## Corresponding CLI version
 
-* Stable CLI version `v3.57.16`
-* Staging CLI version: `v4.2.0`
+* CLI version `v4.2.0`
 
 ## New Recipes
 

--- a/docs/changelog/8-81-0-Release.md
+++ b/docs/changelog/8-81-0-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.57.16`
-* Staging CLI version: `v3.57.16`
+* Staging CLI version: `v4.2.0`
 
 ## New Recipes
 

--- a/docs/changelog/8-83-0-Release.md
+++ b/docs/changelog/8-83-0-Release.md
@@ -13,7 +13,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 ## Corresponding CLI version
 
 * Stable CLI version `v3.57.16`
-* Staging CLI version: `v3.57.16`
+* Staging CLI version: `v4.2.9`
 
 ## New Recipes
 

--- a/docs/changelog/8-83-0-Release.md
+++ b/docs/changelog/8-83-0-Release.md
@@ -12,8 +12,7 @@ This changelog only shows what recipes have been added, removed, or changed. Ope
 
 ## Corresponding CLI version
 
-* Stable CLI version `v3.57.16`
-* Staging CLI version: `v4.2.9`
+* CLI version `v4.2.9`
 
 ## New Recipes
 


### PR DESCRIPTION
Three recent changelogs listed the staging CLI version as `v3.57.16`, the last stable 3.x release, due to a now-fixed bug in the recipe-markdown-generator (openrewrite/rewrite-recipe-markdown-generator#341).

This corrects each to the 4.x Moderne CLI release that shipped the corresponding OpenRewrite version, correlated through \`moderne-recipe-bom\` and \`rewrite-recipe-bom\` (and confirmed by matching release dates): 8.79.1 → \`v4.1.1\`, 8.81.0 → \`v4.2.0\`, 8.83.0 → \`v4.2.9\`. The stable CLI version lines are left unchanged.


`moderne-recipe-bom` links a `moderne-cli` version to a `rewrite-recipe-bom` version, and `rewrite-recipe-bom` pins the `rewrite-bom` (OpenRewrite 8.x) version the changelog is about:

8.81.0 → moderne-recipe-bom 0.35.0 → rewrite-recipe-bom 3.30.0 → rewrite-bom 8.81.0 → moderne-cli 4.2.0
8.83.0 → moderne-recipe-bom 0.36.0 → rewrite-recipe-bom 3.31.0 → rewrite-bom 8.83.0 → moderne-cli 4.2.9
8.79.1 → the 8.79 line is carried by moderne-recipe-bom 0.33.0 → rewrite-recipe-bom 3.28.0 → rewrite-bom 8.79.0 → moderne-cli 4.1.1

Maven Central release dates corroborate each one: 4.2.0 (2026-04-27) and 4.2.9 (2026-05-21) match their changelog dates exactly; 4.1.1 (2026-04-08) lands right at the 8.79.1 changelog date (2026-04-09). I also verified the 8.79 case by jar inspection — 4.1.2 (the next release) had already moved to the 8.80.0-SNAPSHOT line, confirming 4.1.1 as the right CLI for the 8.79 changelog rather than 4.1.2.