### PR TITLE
Fix go doc generation error

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -29,6 +29,23 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'        # recipes-go and rewrite-go both require go 1.25 (their go.mod)
+      - name: Build the rewrite-go-rpc server
+        run: |
+          # Pin GOROOT to the toolchain setup-go just put on PATH. Otherwise GoRewriteRpc discovers
+          # GOROOT via GoExecutor.find(), which prefers /usr/bin/go (the runner image's older default
+          # Go) over PATH, and hands the RPC server a GOROOT from a different release than the `go` it
+          # shells out to: `compile: version "go1.24.13" does not match go tool version "go1.25.12"`.
+          echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
+
+          # The generator's Go loader launches `rewrite-go-rpc` from PATH. It isn't published as a
+          # binary, so build it from source. `go install` names the binary after its package dir (`rpc`),
+          # so symlink it to the name the loader expects, and expose it to later steps via $GITHUB_PATH.
+          go install github.com/openrewrite/rewrite/rewrite-go/cmd/rpc@latest
+          ln -sf "$(go env GOPATH)/bin/rpc" "$(go env GOPATH)/bin/rewrite-go-rpc"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       # Run generator
       - uses: actions/checkout@v7


### PR DESCRIPTION
Doc build failed here: https://github.com/openrewrite/rewrite-docs/actions/runs/30466628908

- Looks like we just didn't port over the Moderne Docs changes here: https://github.com/moderneinc/moderne-docs/pull/897