### PR TITLE
Remove recipeCsvGenerate goal from Maven plugin docs

### DIFF
--- a/docs/reference/rewrite-maven-plugin.md
+++ b/docs/reference/rewrite-maven-plugin.md
@@ -18,7 +18,6 @@ The OpenRewrite Maven plugin offers these goals:
 * `mvn rewrite:dryRunNoFork` - Generate warnings to the console for any recipe that would make changes and generates a diff file in each Maven module's `target` folder. This variant does not fork the Maven life cycle and can be a more efficient choice when using Rewrite within a CI workflow when combined with other Maven goals.
 * `mvn rewrite:discover` - Generate a report of available recipes found on the classpath.
 * `mvn rewrite:typetable` - [Generate a type table](/authoring-recipes/multiple-versions#typetable-generation-for-maven-projects) to support multiple versions of a single library.
-* `mvn rewrite:recipeCsvGenerate` - Generate a `recipes.csv` marketplace file from the recipes found in this project.
 
 :::info
 _`rewrite`_ name-spaced properties can be used for substituting plugin properties:
@@ -142,18 +141,6 @@ To find out what recipes a rewrite module provides, see its documentation and th
 ## The "TypeTable" goal
 
 Execute `mvn rewrite:typetable` to [generate a type table](/authoring-recipes/multiple-versions#typetable-generation-for-maven-projects) to support multiple versions of a single library.
-
-## The "recipeCsvGenerate" goal
-
-Execute `mvn rewrite:recipeCsvGenerate` to generate a `recipes.csv` [marketplace](https://docs.moderne.io/user-documentation/moderne-cli/references/recipes-csv/) file from the recipes found in this project. This is the Maven equivalent of the Gradle `recipeCsvGenerate` task provided by the [OpenRewrite Gradle build plugin](https://github.com/openrewrite/rewrite-build-gradle-plugin).
-
-The goal scans compiled classes and resources in `target/classes/` for recipe definitions (both Java class-based and YAML declarative recipes) and writes the result to `src/main/resources/META-INF/rewrite/recipes.csv`. If an existing `recipes.csv` is present, generated data is merged into it, preserving any manually added entries such as custom category assignments.
-
-The goal automatically forks the Maven lifecycle to `process-classes`, so classes and resources will be compiled before scanning.
-
-:::info
-For more details on the CSV format and how it is used by the Moderne CLI, see the [Moderne docs on the CSV recipe marketplace](https://docs.moderne.io/user-documentation/moderne-cli/references/recipes-csv).
-:::
 
 ## The "Run" goal
 


### PR DESCRIPTION
- The `recipeCsvGenerate` goal was reverted out of the OpenRewrite Maven Plugin in [v6.45.1](https://github.com/openrewrite/rewrite-maven-plugin/releases/tag/v6.45.1) (openrewrite/rewrite-maven-plugin#1185), so remove it from the goal list and drop its dedicated section.