### PR TITLE
Add Intro to OpenRewrite course promos

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -43,7 +43,10 @@ assertTrue(condition);
 
 ## Get started
 
-* New to OpenRewrite? Start with the free, self-paced [Intro to OpenRewrite course](https://www.moderne.ai/training/intro-to-openrewrite-course) to learn the fundamentals, set up the CLI, and run your first recipes.
+:::info[Free Course]
+New to OpenRewrite? Start with the free, self-paced [Intro to OpenRewrite course](https://www.moderne.ai/training/intro-to-openrewrite-course) to learn the fundamentals, set up the CLI, and run your first recipes.
+:::
+
 * If you want to jump right in and run recipes on some sample code, check out our [quickstart guide](./running-recipes/getting-started.md).
 * If you want to learn how to create your own recipes, start with the [Recipe Development Environment guide](./authoring-recipes/recipe-development-environment.md) and then work through the [Writing a Java Refactoring Recipe guide](./authoring-recipes/writing-a-java-refactoring-recipe.md).
 * If you have questions, join us in [Slack](https://join.slack.com/t/rewriteoss/shared_invite/zt-nj42n3ea-b~62rIHzb3Vo0E1APKCXEA) or [Discord](https://discord.gg/xk3ZKrhWAb). We're happy to answer your questions directly.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -43,6 +43,7 @@ assertTrue(condition);
 
 ## Get started
 
+* New to OpenRewrite? Start with the free, self-paced [Intro to OpenRewrite course](https://www.moderne.ai/training/intro-to-openrewrite-course) to learn the fundamentals, set up the CLI, and run your first recipes.
 * If you want to jump right in and run recipes on some sample code, check out our [quickstart guide](./running-recipes/getting-started.md).
 * If you want to learn how to create your own recipes, start with the [Recipe Development Environment guide](./authoring-recipes/recipe-development-environment.md) and then work through the [Writing a Java Refactoring Recipe guide](./authoring-recipes/writing-a-java-refactoring-recipe.md).
 * If you have questions, join us in [Slack](https://join.slack.com/t/rewriteoss/shared_invite/zt-nj42n3ea-b~62rIHzb3Vo0E1APKCXEA) or [Discord](https://discord.gg/xk3ZKrhWAb). We're happy to answer your questions directly.

--- a/docs/training.md
+++ b/docs/training.md
@@ -6,6 +6,12 @@ description: Training resources for learning OpenRewrite and Moderne.
 
 Whether you're brand new to OpenRewrite or looking to sharpen advanced skills, these resources will help you learn to run, write, and reason about recipes.
 
+## Intro to OpenRewrite course
+
+New to OpenRewrite? This free, self-paced course walks you through the fundamentals: core concepts like Lossless Semantic Trees and recipes, setting up the CLI, running and customizing existing recipes, and analyzing your results. No prior experience required.
+
+[Start the Intro to OpenRewrite course](https://www.moderne.ai/training/intro-to-openrewrite-course)
+
 ## Hands-on learning workshops
 
 These interactive, self-paced workshops take you from running your first recipe all the way through writing your own. Along the way you'll cover the fundamentals of recipe development, advanced recipe development, how to prepare for a Spring Boot migration, and AI-assisted recipe authoring.
@@ -23,12 +29,6 @@ If you want to understand the techniques behind OpenRewrite's most sophisticated
 Every week, the Moderne team hosts a live Code Remix session where they talk through the latest changes, answer community questions, and dig into specific topics. Each session is archived with a summary and the key links so you can catch up on anything you missed.
 
 [Browse Code Remix sessions](https://www.youtube.com/@Moderne-and-OpenRewrite/streams)
-
-## Live OpenRewrite training
-
-If you'd rather learn directly from the team, Moderne runs scheduled live OpenRewrite training sessions where you can ask questions in real time.
-
-[See upcoming live training](https://www.moderne.ai/moderne-openrewrite-training-hub)
 
 ## Automated Software Refactoring with OpenRewrite and Generative AI
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -8,9 +8,11 @@ Whether you're brand new to OpenRewrite or looking to sharpen advanced skills, t
 
 ## Intro to OpenRewrite course
 
+:::info[Free Course]
 New to OpenRewrite? This free, self-paced course walks you through the fundamentals: core concepts like Lossless Semantic Trees and recipes, setting up the CLI, running and customizing existing recipes, and analyzing your results. No prior experience required.
 
 [Start the Intro to OpenRewrite course](https://www.moderne.ai/training/intro-to-openrewrite-course)
+:::
 
 ## Hands-on learning workshops
 


### PR DESCRIPTION
Adds promos for the free, self-paced **Intro to OpenRewrite** course, per the docs placements in the course promotion plan.

## What changed

**`docs/training.md`**
- Added **Intro to OpenRewrite course** as the new first section, above "Hands-on learning workshops."
- Removed the **Live OpenRewrite training** section. The on-demand course replaces it, and keeping both created ambiguity about which learning path to take.

**`docs/introduction.md`**
- Added the course to "Get started," above the existing bullet list.

Both promos use `:::info[Free Course]` admonitions so they read as promos rather than body copy, matching the existing `[Free Workshop]` / `[Free Training]` convention used for prior training promos. Copy is taken from the promotion plan verbatim.

## Why these two placements

They were ranked highest by organic first-touch user volume — they reach people already trying to learn or use OpenRewrite, which is the intended audience for an entry-level course.

## Notes for reviewers

- **Please confirm the course URL is live before merging.** The plan's section header says destinations use a `[COURSE URL]` placeholder "until the final URL is set," but the placement copy then gives a concrete link. I used the concrete one: `https://www.moderne.ai/training/intro-to-openrewrite-course`
- **Host:** the plan writes the URL bare (`moderne.ai`); I used `www.moderne.ai` to match this repo, which uses `www` in all 8 existing occurrences and in all four prior training promos. Easy to flip if the bare host is intentional.
- **Homepage placement deviates slightly from the plan**, which specified the course as the top bullet in "Get started." It's now a callout above that list instead, for prominence. Trivial to revert to a bullet if you'd rather match the plan exactly.
- Checked repo-wide: removing the live-training section leaves no orphaned references to it or to the old training-hub link.
- Remaining sections of the promotion plan are out of scope here — they cover moderne.ai, email, LinkedIn/Baeldung/JUGs, reo.dev, and Stack Overflow. Note the plan also flags a "Free live training" item on moderne.ai/openrewrite as the same cleanup done here, owned separately.